### PR TITLE
Log server errors in detail

### DIFF
--- a/sos21-api-server/src/filter/authentication.rs
+++ b/sos21-api-server/src/filter/authentication.rs
@@ -59,7 +59,7 @@ async fn handle_validation(
     let claims = match validate_token(&config, key_store, bearer).await {
         Ok(cs) => cs,
         Err(error) => {
-            event!(Level::INFO, %error, "Invalid token");
+            event!(Level::INFO, ?error, "Invalid token");
             return Err(warp::reject::custom(AuthenticationError::InvalidToken));
         }
     };

--- a/sos21-api-server/src/filter/error.rs
+++ b/sos21-api-server/src/filter/error.rs
@@ -24,7 +24,7 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
     } else if let Some(err) = err.find::<ErasedHandlerError>() {
         match err {
             ErasedHandlerError::Server(error) => {
-                event!(Level::ERROR, %error, "Unexpected error in handler");
+                event!(Level::ERROR, ?error, "Unexpected error in handler");
                 Error {
                     error: ErrorBody::Internal,
                     status: StatusCode::INTERNAL_SERVER_ERROR,

--- a/sos21-api-server/src/main.rs
+++ b/sos21-api-server/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
     tracing_subscriber::fmt().pretty().init();
 
     if let Err(error) = run(opt) {
-        event!(Level::ERROR, %error);
+        event!(Level::ERROR, ?error);
     }
 }
 

--- a/sos21-api-server/src/server.rs
+++ b/sos21-api-server/src/server.rs
@@ -31,7 +31,7 @@ fn spawn_key_refresh_worker(key_store: KeyStore) -> JoinHandle<Infallible> {
                 Err(error) => {
                     event!(
                         Level::ERROR,
-                        %error,
+                        ?error,
                         retry = FETCH_MINIMUM_INTERVAL,
                         "Failed to refresh JWT keys",
                     );

--- a/sos21-database/src/query/list_form_answers_by_form.rs
+++ b/sos21-database/src/query/list_form_answers_by_form.rs
@@ -1,7 +1,7 @@
 use crate::model::form_answer::FormAnswer;
 
-use anyhow::Result;
-use futures::stream::{BoxStream, StreamExt, TryStreamExt};
+use anyhow::{Context, Result};
+use futures::stream::{BoxStream, StreamExt};
 use uuid::Uuid;
 
 pub fn list_form_answers_by_form<'a, E>(conn: E, form_id: Uuid) -> BoxStream<'a, Result<FormAnswer>>
@@ -14,6 +14,6 @@ where
         form_id
     )
     .fetch(conn)
-    .map_err(anyhow::Error::msg)
+    .map(|result| result.context("Failed to select from form_answers"))
     .boxed()
 }

--- a/sos21-database/src/query/list_projects_by_owner.rs
+++ b/sos21-database/src/query/list_projects_by_owner.rs
@@ -1,7 +1,7 @@
 use crate::model::project::Project;
 
-use anyhow::Result;
-use futures::stream::{BoxStream, StreamExt, TryStreamExt};
+use anyhow::{Context, Result};
+use futures::stream::{BoxStream, StreamExt};
 
 pub fn list_projects_by_owner<'a, E>(conn: E, owner_id: String) -> BoxStream<'a, Result<Project>>
 where
@@ -13,6 +13,6 @@ where
         owner_id
     )
     .fetch(conn)
-    .map_err(anyhow::Error::msg)
+    .map(|result| result.context("Failed to select from projects"))
     .boxed()
 }

--- a/sos21-database/src/query/list_users.rs
+++ b/sos21-database/src/query/list_users.rs
@@ -1,7 +1,7 @@
 use crate::model::user::User;
 
-use anyhow::Result;
-use futures::stream::{BoxStream, StreamExt, TryStreamExt};
+use anyhow::{Context, Result};
+use futures::stream::{BoxStream, StreamExt};
 
 pub fn list_users<'a, E>(conn: E) -> BoxStream<'a, Result<User>>
 where
@@ -9,6 +9,6 @@ where
 {
     sqlx::query_as_unchecked!(User, "SELECT * FROM users")
         .fetch(conn)
-        .map_err(anyhow::Error::msg)
+        .map(|result| result.context("Failed to select from users"))
         .boxed()
 }

--- a/sos21-run-migrations/src/main.rs
+++ b/sos21-run-migrations/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
     tracing_subscriber::fmt().pretty().init();
 
     if let Err(error) = run(opt) {
-        event!(Level::ERROR, %error);
+        event!(Level::ERROR, ?error);
     }
 }
 

--- a/sos21-use-case/src/export_form_answers.rs
+++ b/sos21-use-case/src/export_form_answers.rs
@@ -74,7 +74,7 @@ where
         write_record(&mut writer, &input, &form, answer)?;
     }
 
-    let csv = writer.into_inner().map_err(anyhow::Error::msg)?;
+    let csv = writer.into_inner().context("Failed to write CSV data")?;
     Ok(csv)
 }
 

--- a/sos21-use-case/src/export_projects.rs
+++ b/sos21-use-case/src/export_projects.rs
@@ -85,7 +85,7 @@ where
         write_record(&mut writer, &input, project, owner.name, owner.kana_name)?;
     }
 
-    let csv = writer.into_inner().map_err(anyhow::Error::msg)?;
+    let csv = writer.into_inner().context("Failed to write CSV data")?;
     Ok(csv)
 }
 

--- a/sos21-use-case/src/export_users.rs
+++ b/sos21-use-case/src/export_users.rs
@@ -67,7 +67,7 @@ where
         write_record(&mut writer, &input, user)?;
     }
 
-    let csv = writer.into_inner().map_err(anyhow::Error::msg)?;
+    let csv = writer.into_inner().context("Failed to write CSV data")?;
     Ok(csv)
 }
 


### PR DESCRIPTION
- `anyhow::Error` を `Display` で表示していたがそれは一番表層のエラーしか見せないので `Debug` を使うように変更
- `anyhow::Error::msg` を `std::error::Error` に使うのは情報が減ってもったいないので使うのをやめる