### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
+- Update dependencies ([#47](https://github.com/sohosai/sos21-backend/pull/47))
+
 ## [0.2.1] - 2021-03-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,9 +852,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -867,7 +867,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project 1.0.4",
- "socket2",
+ "socket2 0.4.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "libgit2-sys"
@@ -1111,7 +1111,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi",
 ]
 
@@ -1925,6 +1925,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
  "libc",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dafd0aac2818a94a34df0df1100a7356c493d8ede4393875fd0b5c51bb6bc80"
+checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
 dependencies = [
  "bytes",
  "futures",
@@ -2751,7 +2751,6 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -445,7 +445,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@ pkgs.rustPlatform.buildRustPackage {
   version = "0.2.1";
   src = ./.;
 
-  cargoSha256 = "0q6mrwlc5r5fkhspdzglvd01y7dgd31fdvmrddma315pyvys6sg7";
+  cargoSha256 = "03f69nvcx63kcxdr1cvcwn48fgjbwvs3hxh8jdj0mf2a0khxh6r7";
 
   nativeBuildInputs = with pkgs; [
     zlib

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@ pkgs.rustPlatform.buildRustPackage {
   version = "0.2.1";
   src = ./.;
 
-  cargoSha256 = "14kfi0prc36cqmlawn22jc9wmmwyqi7mykbbdamkqaykzg7fr4vk";
+  cargoSha256 = "0q6mrwlc5r5fkhspdzglvd01y7dgd31fdvmrddma315pyvys6sg7";
 
   nativeBuildInputs = with pkgs; [
     zlib

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@ pkgs.rustPlatform.buildRustPackage {
   version = "0.2.1";
   src = ./.;
 
-  cargoSha256 = "1idrfs6avjm6cx75mx13pa9syjsb5q9xx1ywi4v1rlkgzzffnh5m";
+  cargoSha256 = "14kfi0prc36cqmlawn22jc9wmmwyqi7mykbbdamkqaykzg7fr4vk";
 
   nativeBuildInputs = with pkgs; [
     zlib

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@ pkgs.rustPlatform.buildRustPackage {
   version = "0.2.1";
   src = ./.;
 
-  cargoSha256 = "020252zd06g1vl24zh0z86xd50x8cknyrw3ibg5bbmh1z0x6qv7f";
+  cargoSha256 = "1idrfs6avjm6cx75mx13pa9syjsb5q9xx1ywi4v1rlkgzzffnh5m";
 
   nativeBuildInputs = with pkgs; [
     zlib

--- a/sos21-api-server/CHANGELOG.md
+++ b/sos21-api-server/CHANGELOG.md
@@ -22,6 +22,8 @@ with the HTTP API interface being the "public API".
 
 ### Security
 
+- Update dependencies ([#47](https://github.com/sohosai/sos21-backend/pull/47))
+
 ## [0.2.1] - 2021-03-21
 
 No changes in `sos21-api-server`.

--- a/sos21-api-server/Cargo.toml
+++ b/sos21-api-server/Cargo.toml
@@ -19,7 +19,7 @@ async-trait = "0.1.42"
 thiserror = "1"
 chrono = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
-warp = { version = "0.3", default-features = false }
+warp = { version = "0.3.1", default-features = false }
 sqlx = { version = "0.5", features = ["postgres", "runtime-tokio-rustls"] }
 jsonwebtoken = "7"
 mime = "0.3"


### PR DESCRIPTION
- `warp` 0.3.0 to 0.3.1
- `pin-project-lite` 0.2.4 (yanked) to 0.2.6
- hyper 0.14.2 to 0.14.5
  - [RUSTSEC-2021-0020](https://rustsec.org/advisories/RUSTSEC-2021-0020.html)
- generic-array 0.12.3 to 0.12.4
  - [RUSTSEC-2020-0146](https://rustsec.org/advisories/RUSTSEC-2020-0146.html)