### PR TITLE
Workaround not to execute generate-lockfile in audit CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - uses: cachix/cachix-action@v8
+        with:
+          name: sos21-backend
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      # workaround for actions-rs/audit-check#163
+      - run: nix-env -if ./nix/ignore-generate-lockfile-cargo.nix
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/nix/ignore-generate-lockfile-cargo.nix
+++ b/nix/ignore-generate-lockfile-cargo.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import ./pkgs.nix }:
+pkgs.writeShellScriptBin "cargo" ''
+  if [ "$1" == "generate-lockfile" ]; then
+    1>&2 echo 'Ignoring `cargo generate-lockfile`'
+    exit 0
+  fi
+  ${pkgs.cargo}/bin/cargo "$@"
+''


### PR DESCRIPTION
https://github.com/sohosai/sos21-backend/issues/61#issuecomment-821928680

自分で書くのはキツいので `generate-lockfile` を無視させて対処