### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,12 +343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-
-[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,13 +1867,13 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
+checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -2174,7 +2168,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha-1 0.9.2",
+ "sha-1 0.9.6",
  "sha2",
  "smallvec",
  "sqlformat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,13 +1892,13 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -951,16 +951,6 @@ rec {
         ];
         
       };
-      "cpuid-bool" = rec {
-        crateName = "cpuid-bool";
-        version = "0.1.2";
-        edition = "2018";
-        sha256 = "0d16n378jl0n2dslspqxgsiw9frmjirdszhj5gfccgd0548wmswa";
-        authors = [
-          "RustCrypto Developers"
-        ];
-        
-      };
       "crc" = rec {
         crateName = "crc";
         version = "1.8.1";
@@ -5228,11 +5218,11 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "std" ];
       };
-      "sha-1 0.9.2" = rec {
+      "sha-1 0.9.6" = rec {
         crateName = "sha-1";
-        version = "0.9.2";
+        version = "0.9.6";
         edition = "2018";
-        sha256 = "0z2hj8br511bsarw97h82872zqn7ba4738gjws74j2k2bqdxyg6f";
+        sha256 = "05jfwssqvpcy0sr1pcdhdn9awalwsazclimbgzpx0cjq3isglk4c";
         libName = "sha1";
         authors = [
           "RustCrypto Developers"
@@ -5247,8 +5237,18 @@ rec {
             packageId = "cfg-if 1.0.0";
           }
           {
-            name = "cpuid-bool";
-            packageId = "cpuid-bool";
+            name = "cpufeatures";
+            packageId = "cpufeatures";
+            target = { target, features }: (stdenv.hostPlatform.config == "aarch64-apple-darwin");
+          }
+          {
+            name = "cpufeatures";
+            packageId = "cpufeatures";
+            target = { target, features }: ((target."arch" == "aarch64") && (target."os" == "linux"));
+          }
+          {
+            name = "cpufeatures";
+            packageId = "cpufeatures";
             target = { target, features }: ((target."arch" == "x86") || (target."arch" == "x86_64"));
           }
           {
@@ -5268,7 +5268,7 @@ rec {
           }
         ];
         features = {
-          "asm" = [ "sha1-asm" "libc" ];
+          "asm" = [ "sha1-asm" ];
           "asm-aarch64" = [ "asm" ];
           "default" = [ "std" ];
           "std" = [ "digest/std" ];
@@ -6292,7 +6292,7 @@ rec {
           }
           {
             name = "sha-1";
-            packageId = "sha-1 0.9.2";
+            packageId = "sha-1 0.9.6";
             optional = true;
             usesDefaultFeatures = false;
           }

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -929,6 +929,28 @@ rec {
         features = {
         };
       };
+      "cpufeatures" = rec {
+        crateName = "cpufeatures";
+        version = "0.1.4";
+        edition = "2018";
+        sha256 = "1j0i97325c2grndsfgnm3lqk0xbyvdl2dbgn8i5dd9yhnmycc07d";
+        authors = [
+          "RustCrypto Developers"
+        ];
+        dependencies = [
+          {
+            name = "libc";
+            packageId = "libc";
+            target = { target, features }: (stdenv.hostPlatform.config == "aarch64-apple-darwin");
+          }
+          {
+            name = "libc";
+            packageId = "libc";
+            target = { target, features }: ((target."arch" == "aarch64") && (target."os" == "linux"));
+          }
+        ];
+        
+      };
       "cpuid-bool" = rec {
         crateName = "cpuid-bool";
         version = "0.1.2";
@@ -5265,9 +5287,9 @@ rec {
       };
       "sha2" = rec {
         crateName = "sha2";
-        version = "0.9.2";
+        version = "0.9.5";
         edition = "2018";
-        sha256 = "1a225akwq8k1ym827f8f72rfgxaf7zdnnq07qpcblj91zs3anykf";
+        sha256 = "04lzf4swq6cijvxnc6facr3g72h5v7a5z8lz3xrkf8gxa9bswqmk";
         authors = [
           "RustCrypto Developers"
         ];
@@ -5281,8 +5303,18 @@ rec {
             packageId = "cfg-if 1.0.0";
           }
           {
-            name = "cpuid-bool";
-            packageId = "cpuid-bool";
+            name = "cpufeatures";
+            packageId = "cpufeatures";
+            target = { target, features }: (stdenv.hostPlatform.config == "aarch64-apple-darwin");
+          }
+          {
+            name = "cpufeatures";
+            packageId = "cpufeatures";
+            target = { target, features }: ((target."arch" == "aarch64") && (target."os" == "linux"));
+          }
+          {
+            name = "cpufeatures";
+            packageId = "cpufeatures";
             target = { target, features }: ((target."arch" == "x86") || (target."arch" == "x86_64"));
           }
           {
@@ -5302,7 +5334,7 @@ rec {
           }
         ];
         features = {
-          "asm" = [ "sha2-asm" "libc" ];
+          "asm" = [ "sha2-asm" ];
           "asm-aarch64" = [ "asm" ];
           "default" = [ "std" ];
           "std" = [ "digest/std" ];


### PR DESCRIPTION
fix #82

- `sha2` 0.9.2 to 0.9.5
  - [CHANGELOG](https://github.com/RustCrypto/hashes/blob/master/sha2/CHANGELOG.md#095-2021-05-11)
- `sha-1` 0.9.2 to 0.9.6
  - [CHANGELOG](https://github.com/RustCrypto/hashes/blob/master/sha1/CHANGELOG.md#096-2021-05-11)