### PR TITLE
Fix to use fixed rust distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix-env -f ./nix/pkgs.nix -iA rustPlatform.rust.cargo
       - uses: actions-rs/clippy-check@v1
+        env:
+          # Prevent searching $HOME/.cargo/bin for subcommands (rust-lang/cargo#6507)
+          CARGO_HOME: ./.cargo
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           args: -- -D warnings

--- a/nix/rustPlatform.nix
+++ b/nix/rustPlatform.nix
@@ -1,5 +1,9 @@
-{ rustChannels, makeRustPlatform }:
-let channel = rustChannels.stable;
+{ rustChannelOf, makeRustPlatform }:
+let
+  channel = rustChannelOf {
+    channel = "1.52.1";
+    sha256 = "157iggldvb9lcr45zsld6af63yp370f3hyswcb0zwjranrg69r79";
+  };
 in
 makeRustPlatform {
   rustc = channel.rust;


### PR DESCRIPTION
`rustChannels` `rustChannelOf` が Nix expression の評価時にチャンネルをダウンロードしていたので時期によって `rustChannels.stable` の値が異なっていた。今まで使っていたバージョンを使うとともに `sha256` で固定する。