### PR TITLE
Update tokio to 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 ### Security
 
+- Update `tokio` to 1.8.1 ([#114](https://github.com/sohosai/sos21-backend/pull/114))
+
 ## [0.5.1] - 2021-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,9 +2457,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.0.2"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2477,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7142,9 +7142,9 @@ rec {
       };
       "tokio" = rec {
         crateName = "tokio";
-        version = "1.0.2";
+        version = "1.8.1";
         edition = "2018";
-        sha256 = "1v7nrwwnmlv3f6xlhd4xwzjq7h8aysc5gdjph1ilqizjdzn4r80c";
+        sha256 = "11g9x25mrs5589jqdcxq4igryy2k0c893lrxss1ylxacq5fv1j4q";
         authors = [
           "Tokio Contributors <team@tokio.rs>"
         ];
@@ -7225,7 +7225,7 @@ rec {
           "full" = [ "fs" "io-util" "io-std" "macros" "net" "parking_lot" "process" "rt" "rt-multi-thread" "signal" "sync" "time" ];
           "io-util" = [ "memchr" "bytes" ];
           "macros" = [ "tokio-macros" ];
-          "net" = [ "libc" "mio/os-poll" "mio/os-util" "mio/tcp" "mio/udp" "mio/uds" ];
+          "net" = [ "libc" "mio/os-poll" "mio/os-util" "mio/tcp" "mio/udp" "mio/uds" "winapi/namedpipeapi" ];
           "process" = [ "bytes" "once_cell" "libc" "mio/os-poll" "mio/os-util" "mio/uds" "signal-hook-registry" "winapi/threadpoollegacyapiset" ];
           "rt-multi-thread" = [ "num_cpus" "rt" ];
           "signal" = [ "once_cell" "libc" "mio/os-poll" "mio/uds" "mio/os-util" "signal-hook-registry" "winapi/consoleapi" ];
@@ -7234,9 +7234,9 @@ rec {
       };
       "tokio-macros" = rec {
         crateName = "tokio-macros";
-        version = "1.0.0";
+        version = "1.3.0";
         edition = "2018";
-        sha256 = "150l6wfcqw2rcjaf22qk3z6ca794x0s2c68n5ar18cfafllpsla2";
+        sha256 = "045igm2h1mfjakbi68hrl07dflgs2rfvvjff17ylxgjf3zk3nisl";
         procMacro = true;
         authors = [
           "Tokio Contributors <team@tokio.rs>"


### PR DESCRIPTION
fix #112 

- `tokio` 1.0.1 -> 1.8.1
  - [CHANGELOG](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md#181-july-6-2021)
- `tokio-macros` 1.0.0 -> 1.3.0
  - [CHANGELOG](https://github.com/tokio-rs/tokio/blob/master/tokio-macros/CHANGELOG.md#130-july-7-2021)