### PR TITLE
Update rusoto_* to 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update `tokio` to 1.8.1 ([#114](https://github.com/sohosai/sos21-backend/pull/114))
 - Update `hyper` to 0.14.12 ([#121](https://github.com/sohosai/sos21-backend/pull/121))
+- Update `rusoto_*` to 0.47.0 ([#122](https://github.com/sohosai/sos21-backend/pull/122))
 
 ## [0.5.1] - 2021-06-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,12 +134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,7 +287,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time",
  "winapi",
 ]
 
@@ -311,12 +305,6 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -419,6 +407,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,12 +496,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dotenv"
@@ -813,7 +805,7 @@ dependencies = [
  "http",
  "mime",
  "sha-1 0.8.2",
- "time 0.1.43",
+ "time",
 ]
 
 [[package]]
@@ -859,6 +851,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.1",
  "digest 0.9.0",
 ]
 
@@ -1124,12 +1126,6 @@ dependencies = [
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1657,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aff20978970d47630f08de5f0d04799497818d16cafee5aec90c4b4d0806cf"
+checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1682,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_credential"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91e4c25ea8bfa6247684ff635299015845113baaa93ba8169b9e565701b58e"
+checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1700,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_s3"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc3f56f14ccf91f880b9a9c2d0556d8523e8c155041c54db155b384a1dd1119"
+checksum = "048c2fe811a823ad5a9acc976e8bf4f1d910df719dcf44b15c3e96c5b7a51027"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1713,34 +1709,35 @@ dependencies = [
 
 [[package]]
 name = "rusoto_signature"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486e6b1673ab3e0ba1ded284fb444845fe1b7f41d13989a54dd60f62a7b2baa"
+checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
 dependencies = [
  "base64 0.13.0",
  "bytes",
+ "chrono",
+ "digest 0.9.0",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.11.0",
  "http",
  "hyper",
  "log",
- "md5",
+ "md-5",
  "percent-encoding",
  "pin-project-lite",
  "rusoto_credential",
  "rustc_version",
  "serde",
  "sha2",
- "time 0.2.25",
  "tokio",
 ]
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -1833,18 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -1916,12 +1904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-
-[[package]]
 name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2184,7 +2166,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "hmac",
+ "hmac 0.10.1",
  "itoa",
  "libc",
  "log",
@@ -2247,68 +2229,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "standback"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2beb4d1860a61f571530b3f855a1b538d0200f7871c63331ecd6f17b1f014f8"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stringprep"
@@ -2419,44 +2343,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -459,19 +459,6 @@ rec {
         ];
         
       };
-      "base-x" = rec {
-        crateName = "base-x";
-        version = "0.2.8";
-        edition = "2015";
-        sha256 = "12zj7vgrf7wlc46f6xxc14dq1r6z6vmhn51vkdkp04q37lz1ylm4";
-        authors = [
-          "Alex R. <alexei.rudenko@gmail.com>"
-        ];
-        features = {
-          "default" = [ "std" ];
-        };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
       "base64 0.12.3" = rec {
         crateName = "base64";
         version = "0.12.3";
@@ -852,7 +839,7 @@ rec {
           }
           {
             name = "time";
-            packageId = "time 0.1.43";
+            packageId = "time";
             optional = true;
           }
           {
@@ -925,17 +912,6 @@ rec {
           "yaml" = [ "yaml-rust" ];
         };
         resolvedDefaultFeatures = [ "ansi_term" "atty" "color" "default" "strsim" "suggestions" "vec_map" ];
-      };
-      "const_fn" = rec {
-        crateName = "const_fn";
-        version = "0.4.5";
-        edition = "2018";
-        sha256 = "19plqg6q4i2a1grphpzl68030sffdq1w8zyigbwjrqj9gzgddf98";
-        procMacro = true;
-        authors = [
-          "Taiki Endo <te316e89@gmail.com>"
-        ];
-        
       };
       "constant_time_eq" = rec {
         crateName = "constant_time_eq";
@@ -1132,6 +1108,29 @@ rec {
         version = "0.10.0";
         edition = "2018";
         sha256 = "19iyh7h9qaqrv29dhbd31rm6pq023ry78nw7jwr3qjy3l22zsms8";
+        authors = [
+          "RustCrypto Developers"
+        ];
+        dependencies = [
+          {
+            name = "generic-array";
+            packageId = "generic-array 0.14.4";
+          }
+          {
+            name = "subtle";
+            packageId = "subtle";
+            usesDefaultFeatures = false;
+          }
+        ];
+        features = {
+          "dev" = [ "blobby" ];
+        };
+      };
+      "crypto-mac 0.11.1" = rec {
+        crateName = "crypto-mac";
+        version = "0.11.1";
+        edition = "2018";
+        sha256 = "05672ncc54h66vph42s0a42ljl69bwnqjh0x4xgj2v1395psildi";
         authors = [
           "RustCrypto Developers"
         ];
@@ -1359,16 +1358,6 @@ rec {
             target = { target, features }: target."windows";
             features = [ "knownfolders" "objbase" "shlobj" "winbase" "winerror" ];
           }
-        ];
-        
-      };
-      "discard" = rec {
-        crateName = "discard";
-        version = "1.0.4";
-        edition = "2015";
-        sha256 = "1h67ni5bxvg95s91wgicily4ix7lcw7cq0a5gy9njrybaibhyb91";
-        authors = [
-          "Pauan <pcxunlimited@gmail.com>"
         ];
         
       };
@@ -2231,7 +2220,7 @@ rec {
           }
           {
             name = "time";
-            packageId = "time 0.1.43";
+            packageId = "time";
           }
         ];
         features = {
@@ -2316,7 +2305,7 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" "serde" "std" ];
       };
-      "hmac" = rec {
+      "hmac 0.10.1" = rec {
         crateName = "hmac";
         version = "0.10.1";
         edition = "2018";
@@ -2338,6 +2327,35 @@ rec {
           {
             name = "crypto-mac";
             packageId = "crypto-mac 0.10.0";
+            features = [ "dev" ];
+          }
+        ];
+        features = {
+          "std" = [ "crypto-mac/std" ];
+        };
+      };
+      "hmac 0.11.0" = rec {
+        crateName = "hmac";
+        version = "0.11.0";
+        edition = "2018";
+        sha256 = "16z61aibdg4di40sqi4ks2s4rz6r29w4sx4gvblfph3yxch26aia";
+        authors = [
+          "RustCrypto Developers"
+        ];
+        dependencies = [
+          {
+            name = "crypto-mac";
+            packageId = "crypto-mac 0.11.1";
+          }
+          {
+            name = "digest";
+            packageId = "digest 0.9.0";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "crypto-mac";
+            packageId = "crypto-mac 0.11.1";
             features = [ "dev" ];
           }
         ];
@@ -3047,26 +3065,6 @@ rec {
           "asm" = [ "md5-asm" ];
           "default" = [ "std" ];
           "std" = [ "digest/std" ];
-        };
-      };
-      "md5" = rec {
-        crateName = "md5";
-        version = "0.7.0";
-        edition = "2015";
-        sha256 = "0wcps37hrhz59fkhf8di1ppdnqld6l1w5sdy7jp7p51z0i4c8329";
-        authors = [
-          "Ivan Ukhov <ivan.ukhov@gmail.com>"
-          "Kamal Ahmad <shibe@openmailbox.org>"
-          "Konstantin Stepanov <milezv@gmail.com>"
-          "Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"
-          "Nathan Musoke <nathan.musoke@gmail.com>"
-          "Scott Mabin <scott@mabez.dev>"
-          "Tony Arcieri <bascule@gmail.com>"
-          "Wim de With <register@dewith.io>"
-          "Yosef Dinerstein <yosefdi@gmail.com>"
-        ];
-        features = {
-          "default" = [ "std" ];
         };
         resolvedDefaultFeatures = [ "default" "std" ];
       };
@@ -4600,9 +4598,9 @@ rec {
       };
       "rusoto_core" = rec {
         crateName = "rusoto_core";
-        version = "0.46.0";
+        version = "0.47.0";
         edition = "2018";
-        sha256 = "1kq6116ln369mvjzxjhnin0rg53r0h6mzph81xilf3cpg04z5bq2";
+        sha256 = "1k0n676r9379ivdm4y9439mymrqjd02q1qfx1bvv9h9li4700ksv";
         authors = [
           "Anthony DiMarco <ocramida@gmail.com>"
           "Jimmy Cuadra <jimmy@jimmycuadra.com>"
@@ -4637,7 +4635,7 @@ rec {
           {
             name = "hyper";
             packageId = "hyper";
-            features = [ "client" "http1" "tcp" ];
+            features = [ "client" "http1" "http2" "tcp" ];
           }
           {
             name = "hyper-rustls";
@@ -4702,14 +4700,15 @@ rec {
           "native-tls" = [ "hyper-tls" ];
           "nightly-testing" = [ "rusoto_credential/nightly-testing" ];
           "rustls" = [ "hyper-rustls" ];
+          "rustls-webpki" = [ "hyper-rustls/webpki-tokio" ];
         };
         resolvedDefaultFeatures = [ "hyper-rustls" "rustls" ];
       };
       "rusoto_credential" = rec {
         crateName = "rusoto_credential";
-        version = "0.46.0";
+        version = "0.47.0";
         edition = "2018";
-        sha256 = "13mm05bmd7lv2sl3pada7c8lan01k5967zw4fqjadgx8bv1f94cf";
+        sha256 = "0bxc7cnjfcz6m6rns51yc34mkv9gl2q25ns43ragarmvnxyvcika";
         authors = [
           "Anthony DiMarco <ocramida@gmail.com>"
           "Jimmy Cuadra <jimmy@jimmycuadra.com>"
@@ -4775,9 +4774,9 @@ rec {
       };
       "rusoto_s3" = rec {
         crateName = "rusoto_s3";
-        version = "0.46.0";
+        version = "0.47.0";
         edition = "2018";
-        sha256 = "068ivnhq9csmn56wahah2n63wlnqaq2jv74s1f41zyfc2ipzbhxb";
+        sha256 = "09qhlnvwb5iybjql9kwxf7gi1ngiyj5nx5yck9das8x827l2z304";
         authors = [
           "Anthony DiMarco <ocramida@gmail.com>"
           "Jimmy Cuadra <jimmy@jimmycuadra.com>"
@@ -4818,9 +4817,9 @@ rec {
       };
       "rusoto_signature" = rec {
         crateName = "rusoto_signature";
-        version = "0.46.0";
+        version = "0.47.0";
         edition = "2018";
-        sha256 = "1aibgcmgcq6xajd9h4qxyjvy2pw48js4ya7d3nxf1crscyqyd1jl";
+        sha256 = "1k0bhyfk9dc72q4vba63apkz5b0yf5wj1j5wb1vp82mrhhryjr32";
         authors = [
           "Anthony DiMarco <ocramida@gmail.com>"
           "Jimmy Cuadra <jimmy@jimmycuadra.com>"
@@ -4837,6 +4836,16 @@ rec {
             packageId = "bytes";
           }
           {
+            name = "chrono";
+            packageId = "chrono";
+            usesDefaultFeatures = false;
+            features = [ "clock" ];
+          }
+          {
+            name = "digest";
+            packageId = "digest 0.9.0";
+          }
+          {
             name = "futures";
             packageId = "futures";
           }
@@ -4846,7 +4855,7 @@ rec {
           }
           {
             name = "hmac";
-            packageId = "hmac";
+            packageId = "hmac 0.11.0";
           }
           {
             name = "http";
@@ -4862,8 +4871,8 @@ rec {
             packageId = "log";
           }
           {
-            name = "md5";
-            packageId = "md5";
+            name = "md-5";
+            packageId = "md-5";
           }
           {
             name = "percent-encoding";
@@ -4884,10 +4893,6 @@ rec {
           {
             name = "sha2";
             packageId = "sha2";
-          }
-          {
-            name = "time";
-            packageId = "time 0.2.25";
           }
           {
             name = "tokio";
@@ -4912,10 +4917,11 @@ rec {
       };
       "rustc_version" = rec {
         crateName = "rustc_version";
-        version = "0.2.3";
-        edition = "2015";
-        sha256 = "02h3x57lcr8l2pm0a645s9whdh33pn5cnrwvn5cb57vcrc53x3hk";
+        version = "0.4.0";
+        edition = "2018";
+        sha256 = "0rpk9rcdk405xhbmgclsh4pai0svn49x35aggl4nhbkd4a2zb85z";
         authors = [
+          "Dirkjan Ochtman <dirkjan@ochtman.nl>"
           "Marvin Löbel <loebel.marvin@gmail.com>"
         ];
         dependencies = [
@@ -5152,33 +5158,16 @@ rec {
       };
       "semver" = rec {
         crateName = "semver";
-        version = "0.9.0";
-        edition = "2015";
-        sha256 = "00q4lkcj0rrgbhviv9sd4p6qmdsipkwkbra7rh11jrhq5kpvjzhx";
+        version = "1.0.4";
+        edition = "2018";
+        sha256 = "04l00sn8y7lv1a8j11a6r7vwcm5qmlsdh7zqb0rw2cxab1i8x2jn";
         authors = [
-          "Steve Klabnik <steve@steveklabnik.com>"
-          "The Rust Project Developers"
-        ];
-        dependencies = [
-          {
-            name = "semver-parser";
-            packageId = "semver-parser";
-          }
+          "David Tolnay <dtolnay@gmail.com>"
         ];
         features = {
-          "ci" = [ "serde" ];
+          "default" = [ "std" ];
         };
-        resolvedDefaultFeatures = [ "default" ];
-      };
-      "semver-parser" = rec {
-        crateName = "semver-parser";
-        version = "0.7.0";
-        edition = "2015";
-        sha256 = "18vhypw6zgccnrlm5ps1pwa0khz7ry927iznpr88b87cagr1v2iq";
-        authors = [
-          "Steve Klabnik <steve@steveklabnik.com>"
-        ];
-        
+        resolvedDefaultFeatures = [ "default" "std" ];
       };
       "serde" = rec {
         crateName = "serde";
@@ -5401,17 +5390,6 @@ rec {
           "std" = [ "digest/std" ];
         };
       };
-      "sha1" = rec {
-        crateName = "sha1";
-        version = "0.6.0";
-        edition = "2015";
-        sha256 = "03gs2q4m67rn2p8xcdfxhip6mpgahdwm12bnb3vh90ahv9grhy95";
-        authors = [
-          "Armin Ronacher <armin.ronacher@active-4.com>"
-        ];
-        features = {
-        };
-      };
       "sha2" = rec {
         crateName = "sha2";
         version = "0.9.5";
@@ -5486,13 +5464,17 @@ rec {
       };
       "shlex" = rec {
         crateName = "shlex";
-        version = "0.1.1";
+        version = "1.1.0";
         edition = "2015";
-        sha256 = "1lmv6san7g8dv6jdfp14m7bdczq9ss7j7bgsfqyqjc3jnjfippvz";
+        sha256 = "18zqcay2dgxgrd1r645mb79m4q745jcrqj659k11bwh99lx8bcj3";
         authors = [
           "comex <comexk@gmail.com>"
+          "Fenhl <fenhl@fenhl.net>"
         ];
-        
+        features = {
+          "default" = [ "std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
       };
       "signal-hook-registry" = rec {
         crateName = "signal-hook-registry";
@@ -6337,7 +6319,7 @@ rec {
           }
           {
             name = "hmac";
-            packageId = "hmac";
+            packageId = "hmac 0.10.1";
             optional = true;
             usesDefaultFeatures = false;
           }
@@ -6650,26 +6632,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "_rt-tokio" "_tls-rustls" "once_cell" "runtime-tokio-rustls" "tokio" "tokio-rustls" ];
       };
-      "standback" = rec {
-        crateName = "standback";
-        version = "0.2.15";
-        edition = "2018";
-        sha256 = "1y0ly2qifvyd3qrn6747yw0053ak3dd8agqbadqzaq8ahv8v9gm2";
-        authors = [
-          "Jacob Pratt <open-source@jhpratt.dev>"
-          "The Rust Project Developers"
-        ];
-        buildDependencies = [
-          {
-            name = "version_check";
-            packageId = "version_check";
-          }
-        ];
-        features = {
-          "default" = [ "std" ];
-        };
-        resolvedDefaultFeatures = [ "std" ];
-      };
       "static_assertions" = rec {
         crateName = "static_assertions";
         version = "1.1.0";
@@ -6680,143 +6642,6 @@ rec {
         ];
         features = {
         };
-      };
-      "stdweb" = rec {
-        crateName = "stdweb";
-        version = "0.4.20";
-        edition = "2015";
-        sha256 = "1md14n9rzxzdskz3hpgln8vxfwqsw2cswc0f5nslh4r82rmlj8nh";
-        authors = [
-          "Jan Bujak <j@exia.io>"
-        ];
-        dependencies = [
-          {
-            name = "discard";
-            packageId = "discard";
-          }
-          {
-            name = "stdweb-derive";
-            packageId = "stdweb-derive";
-          }
-          {
-            name = "stdweb-internal-macros";
-            packageId = "stdweb-internal-macros";
-          }
-          {
-            name = "stdweb-internal-runtime";
-            packageId = "stdweb-internal-runtime";
-          }
-          {
-            name = "wasm-bindgen";
-            packageId = "wasm-bindgen";
-            target = { target, features }: ((target."arch" == "wasm32") && (target."vendor" == "unknown") && (target."os" == "unknown") && (!target."cargo_web"));
-          }
-        ];
-        buildDependencies = [
-          {
-            name = "rustc_version";
-            packageId = "rustc_version";
-          }
-        ];
-        features = {
-          "default" = [ "serde" "serde_json" ];
-          "experimental_features_which_may_break_on_minor_version_bumps" = [ "futures-support" ];
-          "futures-support" = [ "futures-core-preview" "futures-channel-preview" "futures-util-preview" "futures-executor-preview" ];
-        };
-      };
-      "stdweb-derive" = rec {
-        crateName = "stdweb-derive";
-        version = "0.5.3";
-        edition = "2015";
-        sha256 = "1vsh7g0gaxn4kxqq3knhymdn02p2pfxmnd2j0vplpj6c1yj60yn8";
-        procMacro = true;
-        authors = [
-          "Jan Bujak <j@exia.io>"
-        ];
-        dependencies = [
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2";
-          }
-          {
-            name = "quote";
-            packageId = "quote";
-          }
-          {
-            name = "serde";
-            packageId = "serde";
-          }
-          {
-            name = "serde_derive";
-            packageId = "serde_derive";
-          }
-          {
-            name = "syn";
-            packageId = "syn";
-            usesDefaultFeatures = false;
-            features = [ "derive" "parsing" "printing" ];
-          }
-        ];
-        
-      };
-      "stdweb-internal-macros" = rec {
-        crateName = "stdweb-internal-macros";
-        version = "0.2.9";
-        edition = "2015";
-        sha256 = "049fq8fl5ny9l5if2qv7kxwng7g6ns95h4fbm3zx360dmpv5zyjq";
-        procMacro = true;
-        authors = [
-          "Jan Bujak <j@exia.io>"
-        ];
-        dependencies = [
-          {
-            name = "base-x";
-            packageId = "base-x";
-          }
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2";
-          }
-          {
-            name = "quote";
-            packageId = "quote";
-          }
-          {
-            name = "serde";
-            packageId = "serde";
-          }
-          {
-            name = "serde_derive";
-            packageId = "serde_derive";
-          }
-          {
-            name = "serde_json";
-            packageId = "serde_json";
-          }
-          {
-            name = "sha1";
-            packageId = "sha1";
-          }
-          {
-            name = "syn";
-            packageId = "syn";
-            usesDefaultFeatures = false;
-            features = [ "full" "parsing" "printing" "clone-impls" ];
-          }
-        ];
-        
-      };
-      "stdweb-internal-runtime" = rec {
-        crateName = "stdweb-internal-runtime";
-        version = "0.1.5";
-        edition = "2015";
-        sha256 = "1h0nkppb4r8dbrbms2hw9n5xdcs392m0r5hj3b6lsx3h6fx02dr1";
-        authors = [
-          "Jan Bujak <j@exia.io>"
-        ];
-        features = {
-        };
-        resolvedDefaultFeatures = [ "default" ];
       };
       "stringprep" = rec {
         crateName = "stringprep";
@@ -7051,7 +6876,7 @@ rec {
         ];
         
       };
-      "time 0.1.43" = rec {
+      "time" = rec {
         crateName = "time";
         version = "0.1.43";
         edition = "2015";
@@ -7076,123 +6901,6 @@ rec {
             name = "winapi";
             packageId = "winapi";
             features = [ "std" "processthreadsapi" "winbase" ];
-          }
-        ];
-        
-      };
-      "time 0.2.25" = rec {
-        crateName = "time";
-        version = "0.2.25";
-        edition = "2018";
-        sha256 = "1xs2l59b1dxjm9w9si37l21k7cqkakw9b4skq9a188icji3b158i";
-        authors = [
-          "Jacob Pratt <the.z.cuber@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "const_fn";
-            packageId = "const_fn";
-          }
-          {
-            name = "libc";
-            packageId = "libc";
-            optional = true;
-            target = { target, features }: target."unix";
-          }
-          {
-            name = "standback";
-            packageId = "standback";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "stdweb";
-            packageId = "stdweb";
-            optional = true;
-            usesDefaultFeatures = false;
-            target = { target, features }: (target."arch" == "wasm32");
-          }
-          {
-            name = "time-macros";
-            packageId = "time-macros";
-          }
-          {
-            name = "winapi";
-            packageId = "winapi";
-            optional = true;
-            target = { target, features }: target."windows";
-            features = [ "minwinbase" "minwindef" "timezoneapi" ];
-          }
-        ];
-        buildDependencies = [
-          {
-            name = "version_check";
-            packageId = "version_check";
-          }
-        ];
-        devDependencies = [
-          {
-            name = "standback";
-            packageId = "standback";
-          }
-        ];
-        features = {
-          "default" = [ "deprecated" "std" ];
-          "std" = [ "libc" "winapi" "stdweb" "standback/std" ];
-        };
-        resolvedDefaultFeatures = [ "default" "deprecated" "libc" "std" "stdweb" "winapi" ];
-      };
-      "time-macros" = rec {
-        crateName = "time-macros";
-        version = "0.1.1";
-        edition = "2018";
-        sha256 = "1wg24yxpxcfmim6dgblrf8p321m7cyxpdivzvp8bcb7i4rp9qzlm";
-        authors = [
-          "Jacob Pratt <the.z.cuber@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "proc-macro-hack";
-            packageId = "proc-macro-hack";
-          }
-          {
-            name = "time-macros-impl";
-            packageId = "time-macros-impl";
-          }
-        ];
-        
-      };
-      "time-macros-impl" = rec {
-        crateName = "time-macros-impl";
-        version = "0.1.1";
-        edition = "2018";
-        sha256 = "1ymqhvnvry3giiw45xvarlgagl8hnd6cz4alkz32fq5dvwgbxhz5";
-        procMacro = true;
-        authors = [
-          "Jacob Pratt <the.z.cuber@gmail.com>"
-        ];
-        dependencies = [
-          {
-            name = "proc-macro-hack";
-            packageId = "proc-macro-hack";
-          }
-          {
-            name = "proc-macro2";
-            packageId = "proc-macro2";
-          }
-          {
-            name = "quote";
-            packageId = "quote";
-          }
-          {
-            name = "standback";
-            packageId = "standback";
-            usesDefaultFeatures = false;
-          }
-          {
-            name = "syn";
-            packageId = "syn";
-            usesDefaultFeatures = false;
-            features = [ "proc-macro" "parsing" "printing" "derive" ];
           }
         ];
         

--- a/sos21-api-server/Cargo.toml
+++ b/sos21-api-server/Cargo.toml
@@ -25,9 +25,9 @@ jsonwebtoken = "7"
 mime = "0.3"
 bytes = "1"
 mpart-async = "0.5"
-rusoto_s3 = { version = "0.46", default-features = false, features = ["rustls"] }
-rusoto_core = { version = "0.46", default-features = false, features = ["rustls"] }
-rusoto_credential = "0.46"
+rusoto_s3 = { version = "0.47", default-features = false, features = ["rustls"] }
+rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }
+rusoto_credential = "0.47"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 url = "2"
 structopt = "0.3"

--- a/sos21-domain/src/model/object/data.rs
+++ b/sos21-domain/src/model/object/data.rs
@@ -23,13 +23,13 @@ struct ObjectDataStream {
     summary_sender: Option<oneshot::Sender<ObjectDataSummary>>,
     acc_size: u64,
     acc_hasher: blake3::Hasher,
-    stream: Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + Sync + 'static>>,
+    stream: Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + 'static>>,
 }
 
 impl ObjectDataStream {
     fn new<S>(stream: S, summary_sender: Option<oneshot::Sender<ObjectDataSummary>>) -> Self
     where
-        S: Stream<Item = Result<Bytes>> + Send + Sync + 'static,
+        S: Stream<Item = Result<Bytes>> + Send + 'static,
     {
         ObjectDataStream {
             summary_sender,
@@ -104,7 +104,7 @@ impl ObjectData {
     /// Creates `ObjectData` by wrapping a stream.
     pub fn from_stream<S>(stream: S) -> Self
     where
-        S: Stream<Item = Result<Bytes>> + Send + Sync + 'static,
+        S: Stream<Item = Result<Bytes>> + Send + 'static,
     {
         ObjectData(ObjectDataStream::new(stream, None))
     }
@@ -117,7 +117,7 @@ impl ObjectData {
     /// reading is complete.
     pub fn from_stream_with_summary<S>(stream: S) -> (Self, ObjectDataSummaryReceiver)
     where
-        S: Stream<Item = Result<Bytes>> + Send + Sync + 'static,
+        S: Stream<Item = Result<Bytes>> + Send + 'static,
     {
         let (tx, rx) = oneshot::channel();
         let receiver = ObjectDataSummaryReceiver(rx);
@@ -127,7 +127,7 @@ impl ObjectData {
         )
     }
 
-    pub fn into_stream(self) -> impl Stream<Item = Result<Bytes>> + Send + Sync + 'static {
+    pub fn into_stream(self) -> impl Stream<Item = Result<Bytes>> + Send + 'static {
         self.0
     }
 }

--- a/sos21-gateway/s3/Cargo.toml
+++ b/sos21-gateway/s3/Cargo.toml
@@ -12,8 +12,8 @@ anyhow = "1"
 async-trait = "0.1.42"
 bytes = "1"
 futures = "0.3"
-rusoto_core = { version = "0.46", default-features = false, features = ["rustls"] }
-rusoto_s3 = { version = "0.46", default-features = false, features = ["rustls"] }
+rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }
+rusoto_s3 = { version = "0.47", default-features = false, features = ["rustls"] }
 thiserror = "1"
 tokio = { version = "1", default-features = false, features = ["rt"] }
 sos21-domain = { path = "../../sos21-domain" }

--- a/sos21-gateway/s3/src/object_repository.rs
+++ b/sos21-gateway/s3/src/object_repository.rs
@@ -164,7 +164,7 @@ struct UploadInput<'a, S> {
 
 async fn upload<S>(input: UploadInput<'_, S>) -> anyhow::Result<StoreObjectResult>
 where
-    S: Stream<Item = anyhow::Result<Bytes>> + Send + Sync + Unpin + 'static,
+    S: Stream<Item = anyhow::Result<Bytes>> + Send + Unpin + 'static,
 {
     let UploadInput {
         client,

--- a/sos21-use-case/src/model/stream.rs
+++ b/sos21-use-case/src/model/stream.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt, TryStreamExt};
 
-pub struct ByteStream(Pin<Box<dyn Stream<Item = anyhow::Result<Bytes>> + Send + Sync + 'static>>);
+pub struct ByteStream(Pin<Box<dyn Stream<Item = anyhow::Result<Bytes>> + Send + 'static>>);
 
 impl Debug for ByteStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -24,8 +24,8 @@ impl Stream for ByteStream {
 impl ByteStream {
     pub fn new<S, E>(stream: S) -> Self
     where
-        S: Stream<Item = Result<Bytes, E>> + Send + Sync + 'static,
-        E: Into<anyhow::Error> + Send + Sync + 'static,
+        S: Stream<Item = Result<Bytes, E>> + Send + 'static,
+        E: Into<anyhow::Error> + Send + 'static,
     {
         ByteStream(Box::pin(stream.map_err(Into::into)))
     }


### PR DESCRIPTION
fix #52 

- rusoto_* v0.46.0 -> v0.47.0
  - [CHANGELOG](https://github.com/rusoto/rusoto/blob/master/CHANGELOG.md#0470---2021-06-29)

<details>

```
    Updating crates.io index
    Removing base-x v0.2.8
    Removing const_fn v0.4.5
      Adding crypto-mac v0.11.1
    Removing discard v1.0.4
      Adding hmac v0.11.0
    Removing md5 v0.7.0
    Updating rusoto_core v0.46.0 -> v0.47.0
    Updating rusoto_credential v0.46.0 -> v0.47.0
    Updating rusoto_s3 v0.46.0 -> v0.47.0
    Updating rusoto_signature v0.46.0 -> v0.47.0
    Updating rustc_version v0.2.3 -> v0.4.0
    Updating semver v0.9.0 -> v1.0.4
    Removing semver-parser v0.7.0
    Removing sha1 v0.6.0
    Updating shlex v0.1.1 -> v1.1.0
    Removing standback v0.2.15
    Removing stdweb v0.4.20
    Removing stdweb-derive v0.5.3
    Removing stdweb-internal-macros v0.2.9
    Removing stdweb-internal-runtime v0.1.5
    Removing time v0.2.25
    Removing time-macros v0.1.1
    Removing time-macros-impl v0.1.1
```

</details>