### PR TITLE
Enable to upload files larger than 10MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Enable to upload files larger than 10MB ([#125](https://github.com/sohosai/sos21-backend/pull/125))
+
 ### Security
 
 ## [0.5.2] - 2021-08-28

--- a/nix/deployment/beta.nix
+++ b/nix/deployment/beta.nix
@@ -20,6 +20,7 @@ in
       locations."/file/create" = {
         proxyPass = "${apiServer}/file/create";
         extraConfig = ''
+          proxy_request_buffering off;
           client_max_body_size 0;
         '';
       };

--- a/nix/deployment/beta.nix
+++ b/nix/deployment/beta.nix
@@ -1,4 +1,7 @@
 { config, pkgs, ... }:
+let
+  apiServer = "http://localhost:${toString config.services.sos21-api-server.port}";
+in
 {
   imports = [
     ./sos21-api-server.nix
@@ -12,7 +15,13 @@
       enableACME = true;
       forceSSL = true;
       locations."/" = {
-        proxyPass = "http://localhost:${toString config.services.sos21-api-server.port}/";
+        proxyPass = apiServer;
+      };
+      locations."/file/create" = {
+        proxyPass = "${apiServer}/file/create";
+        extraConfig = ''
+          client_max_body_size 0;
+        '';
       };
     };
   };

--- a/nix/deployment/main.nix
+++ b/nix/deployment/main.nix
@@ -22,6 +22,7 @@ in
       locations."/file/create" = {
         proxyPass = "${apiServer}/file/create";
         extraConfig = ''
+          proxy_request_buffering off;
           client_max_body_size 0;
         '';
       };

--- a/nix/deployment/main.nix
+++ b/nix/deployment/main.nix
@@ -1,4 +1,7 @@
 { config, pkgs, ... }:
+let
+  apiServer = "http://localhost:${toString config.services.sos21-api-server.port}";
+in
 {
   imports = [
     ./sos21-api-server.nix
@@ -8,11 +11,19 @@
   ];
 
   services.nginx = {
+    clientMaxBodySize = "2m";
+
     virtualHosts."api.online.sohosai.com" = {
       enableACME = true;
       forceSSL = true;
       locations."/" = {
-        proxyPass = "http://localhost:${toString config.services.sos21-api-server.port}/";
+        proxyPass = apiServer;
+      };
+      locations."/file/create" = {
+        proxyPass = "${apiServer}/file/create";
+        extraConfig = ''
+          client_max_body_size 0;
+        '';
       };
     };
   };

--- a/nix/deployment/nightly.nix
+++ b/nix/deployment/nightly.nix
@@ -20,6 +20,7 @@ in
       locations."/file/create" = {
         proxyPass = "${apiServer}/file/create";
         extraConfig = ''
+          proxy_request_buffering off;
           client_max_body_size 0;
         '';
       };

--- a/nix/deployment/nightly.nix
+++ b/nix/deployment/nightly.nix
@@ -1,4 +1,7 @@
 { config, pkgs, ... }:
+let
+  apiServer = "http://localhost:${toString config.services.sos21-api-server.port}";
+in
 {
   imports = [
     ./sos21-api-server.nix
@@ -12,7 +15,13 @@
       enableACME = true;
       forceSSL = true;
       locations."/" = {
-        proxyPass = "http://localhost:${toString config.services.sos21-api-server.port}/";
+        proxyPass = apiServer;
+      };
+      locations."/file/create" = {
+        proxyPass = "${apiServer}/file/create";
+        extraConfig = ''
+          client_max_body_size 0;
+        '';
       };
     };
   };

--- a/sos21-domain/src/model/user/role.rs
+++ b/sos21-domain/src/model/user/role.rs
@@ -64,7 +64,7 @@ impl UserRole {
     pub fn file_usage_quota(&self) -> UserFileUsageQuota {
         match self {
             UserRole::General | UserRole::Committee => {
-                UserFileUsageQuota::limited_number_of_bytes(512 * 1024 * 1024)
+                UserFileUsageQuota::limited_number_of_bytes(1024 * 1024 * 1024)
             }
             UserRole::CommitteeOperator => {
                 UserFileUsageQuota::limited_number_of_bytes(15 * 1024 * 1024 * 1024)


### PR DESCRIPTION
NixOSのデフォルトの10MBの`client_max_body_size`で打ち切られていた: https://github.com/NixOS/nixpkgs/blob/cd63096d6d887d689543a0b97743d28995bc9bc3/nixos/modules/services/web-servers/nginx/default.nix#L486

- `/file/create` だけ `client_max_body_size` をなくす、あとバッファリング外す
- general/committee の quota を 1GB へ