### PR TITLE
Append online/physical suffix on ProjectCategory

### DIFF
--- a/sos21-api-server/schema/api.yml
+++ b/sos21-api-server/schema/api.yml
@@ -1075,6 +1075,7 @@ paths:
                                   - ALREADY_PROJECT_SUBOWNER
                                   - ALREADY_PENDING_PROJECT_OWNER
                                   - OUT_OF_PROJECT_CREATION_PERIOD
+                                  - ARTISTIC_STAGE_PROJECT
                     required:
                       - status
                       - error

--- a/sos21-api-server/schema/model/project/ProjectCategory.yml
+++ b/sos21-api-server/schema/model/project/ProjectCategory.yml
@@ -1,7 +1,9 @@
 type: string
 title: ProjectCategory
 enum:
-  - general
-  - stage
-  - cooking
-  - food
+  - general_online
+  - general_physical
+  - stage_online
+  - stage_physical
+  - cooking_physical
+  - food_physical

--- a/sos21-api-server/src/handler/model/project.rs
+++ b/sos21-api-server/src/handler/model/project.rs
@@ -33,19 +33,23 @@ pub enum ProjectCategory {
 impl ProjectCategory {
     pub fn from_use_case(category: use_case::ProjectCategory) -> ProjectCategory {
         match category {
-            use_case::ProjectCategory::General => ProjectCategory::General,
-            use_case::ProjectCategory::Stage => ProjectCategory::Stage,
-            use_case::ProjectCategory::Cooking => ProjectCategory::Cooking,
-            use_case::ProjectCategory::Food => ProjectCategory::Food,
+            use_case::ProjectCategory::GeneralOnline => ProjectCategory::GeneralOnline,
+            use_case::ProjectCategory::GeneralPhysical => ProjectCategory::GeneralPhysical,
+            use_case::ProjectCategory::StageOnline => ProjectCategory::StageOnline,
+            use_case::ProjectCategory::StagePhysical => ProjectCategory::StagePhysical,
+            use_case::ProjectCategory::CookingPhysical => ProjectCategory::CookingPhysical,
+            use_case::ProjectCategory::FoodPhysical => ProjectCategory::FoodPhysical,
         }
     }
 
     pub fn into_use_case(self) -> use_case::ProjectCategory {
         match self {
-            ProjectCategory::General => use_case::ProjectCategory::General,
-            ProjectCategory::Stage => use_case::ProjectCategory::Stage,
-            ProjectCategory::Cooking => use_case::ProjectCategory::Cooking,
-            ProjectCategory::Food => use_case::ProjectCategory::Food,
+            ProjectCategory::GeneralOnline => use_case::ProjectCategory::GeneralOnline,
+            ProjectCategory::GeneralPhysical => use_case::ProjectCategory::GeneralPhysical,
+            ProjectCategory::StageOnline => use_case::ProjectCategory::StageOnline,
+            ProjectCategory::StagePhysical => use_case::ProjectCategory::StagePhysical,
+            ProjectCategory::CookingPhysical => use_case::ProjectCategory::CookingPhysical,
+            ProjectCategory::FoodPhysical => use_case::ProjectCategory::FoodPhysical,
         }
     }
 }

--- a/sos21-api-server/src/handler/model/project.rs
+++ b/sos21-api-server/src/handler/model/project.rs
@@ -22,10 +22,12 @@ impl ProjectId {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProjectCategory {
-    General,
-    Stage,
-    Cooking,
-    Food,
+    GeneralOnline,
+    GeneralPhysical,
+    StageOnline,
+    StagePhysical,
+    CookingPhysical,
+    FoodPhysical,
 }
 
 impl ProjectCategory {

--- a/sos21-api-server/src/handler/project/create.rs
+++ b/sos21-api-server/src/handler/project/create.rs
@@ -31,6 +31,7 @@ pub enum Error {
     TooManyProjects,
     NotAnsweredRegistrationForm,
     SameOwnerSubowner,
+    ArtisticStageProject,
     AlreadyProjectOwner,
     AlreadyProjectSubowner,
     AlreadyPendingProjectOwner,
@@ -44,6 +45,7 @@ impl HandlerResponse for Error {
             Error::TooManyProjects => StatusCode::CONFLICT,
             Error::NotAnsweredRegistrationForm => StatusCode::CONFLICT,
             Error::SameOwnerSubowner => StatusCode::CONFLICT,
+            Error::ArtisticStageProject => StatusCode::BAD_REQUEST,
             Error::AlreadyProjectOwner => StatusCode::CONFLICT,
             Error::AlreadyProjectSubowner => StatusCode::CONFLICT,
             Error::AlreadyPendingProjectOwner => StatusCode::CONFLICT,
@@ -61,6 +63,7 @@ impl From<create_project::Error> for Error {
                 Error::NotAnsweredRegistrationForm
             }
             create_project::Error::SameOwnerSubowner => Error::SameOwnerSubowner,
+            create_project::Error::ArtisticStageProject => Error::ArtisticStageProject,
             create_project::Error::AlreadyProjectOwner => Error::AlreadyProjectOwner,
             create_project::Error::AlreadyProjectSubowner => Error::AlreadyProjectSubowner,
             create_project::Error::AlreadyPendingProjectOwner => Error::AlreadyPendingProjectOwner,

--- a/sos21-api-server/src/handler/project/export.rs
+++ b/sos21-api-server/src/handler/project/export.rs
@@ -64,10 +64,12 @@ pub struct Request {
     pub field_attribute_committee: Option<String>,
     #[serde(default)]
     pub field_attribute_outdoor: Option<String>,
-    pub category_general: String,
-    pub category_stage: String,
-    pub category_cooking: String,
-    pub category_food: String,
+    pub category_general_online: String,
+    pub category_general_physical: String,
+    pub category_stage_online: String,
+    pub category_stage_physical: String,
+    pub category_cooking_physical: String,
+    pub category_food_physical: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -127,10 +129,12 @@ pub async fn handler(
             field_attribute_artistic,
             field_attribute_committee,
             field_attribute_outdoor,
-            category_general,
-            category_stage,
-            category_cooking,
-            category_food,
+            category_general_online,
+            category_general_physical,
+            category_stage_online,
+            category_stage_physical,
+            category_cooking_physical,
+            category_food_physical,
         } = request;
         let field_names = export_projects::InputFieldNames {
             id: field_id,
@@ -163,10 +167,12 @@ pub async fn handler(
             attribute_outdoor: field_attribute_outdoor,
         };
         let category_names = export_projects::InputCategoryNames {
-            general: category_general,
-            stage: category_stage,
-            cooking: category_cooking,
-            food: category_food,
+            general_online: category_general_online,
+            general_physical: category_general_physical,
+            stage_online: category_stage_online,
+            stage_physical: category_stage_physical,
+            cooking_physical: category_cooking_physical,
+            food_physical: category_food_physical,
         };
         export_projects::Input {
             field_names,

--- a/sos21-api-server/src/handler/project/prepare.rs
+++ b/sos21-api-server/src/handler/project/prepare.rs
@@ -39,6 +39,7 @@ pub enum Error {
     AlreadyProjectSubowner,
     AlreadyPendingProjectOwner,
     OutOfProjectCreationPeriod,
+    ArtisticStageProject,
 }
 
 impl HandlerResponse for Error {
@@ -50,6 +51,7 @@ impl HandlerResponse for Error {
             Error::AlreadyProjectSubowner => StatusCode::CONFLICT,
             Error::AlreadyPendingProjectOwner => StatusCode::CONFLICT,
             Error::OutOfProjectCreationPeriod => StatusCode::CONFLICT,
+            Error::ArtisticStageProject => StatusCode::CONFLICT,
         }
     }
 }
@@ -73,6 +75,7 @@ impl From<prepare_project::Error> for Error {
             prepare_project::Error::AlreadyProjectSubowner => Error::AlreadyProjectSubowner,
             prepare_project::Error::AlreadyPendingProjectOwner => Error::AlreadyPendingProjectOwner,
             prepare_project::Error::OutOfCreationPeriod => Error::OutOfProjectCreationPeriod,
+            prepare_project::Error::ArtisticStageProject => Error::ArtisticStageProject,
         }
     }
 }

--- a/sos21-database/src/command/insert_form_project_query_conjunctions.rs
+++ b/sos21-database/src/command/insert_form_project_query_conjunctions.rs
@@ -25,10 +25,12 @@ where
 
     for conj in query {
         let category = conj.category.as_ref().map(|category| match category {
-            ProjectCategory::General => "general",
-            ProjectCategory::Stage => "stage",
-            ProjectCategory::Cooking => "cooking",
-            ProjectCategory::Food => "food",
+            ProjectCategory::GeneralOnline => "general_online",
+            ProjectCategory::GeneralPhysical => "general_physical",
+            ProjectCategory::StageOnline => "stage_online",
+            ProjectCategory::StagePhysical => "stage_physical",
+            ProjectCategory::CookingPhysical => "cooking_physical",
+            ProjectCategory::FoodPhysical => "food_physical",
         });
         categories.push(category);
         attributes.push(conj.attributes.bits() as i32);

--- a/sos21-database/src/command/insert_registration_form_project_query_conjunctions.rs
+++ b/sos21-database/src/command/insert_registration_form_project_query_conjunctions.rs
@@ -25,10 +25,12 @@ where
 
     for conj in query {
         let category = conj.category.as_ref().map(|category| match category {
-            ProjectCategory::General => "general",
-            ProjectCategory::Stage => "stage",
-            ProjectCategory::Cooking => "cooking",
-            ProjectCategory::Food => "food",
+            ProjectCategory::GeneralOnline => "general_online",
+            ProjectCategory::GeneralPhysical => "general_physical",
+            ProjectCategory::StageOnline => "stage_online",
+            ProjectCategory::StagePhysical => "stage_physical",
+            ProjectCategory::CookingPhysical => "cooking_physical",
+            ProjectCategory::FoodPhysical => "food_physical",
         });
         categories.push(category);
         attributes.push(conj.attributes.bits() as i32);

--- a/sos21-database/src/model/project.rs
+++ b/sos21-database/src/model/project.rs
@@ -11,10 +11,12 @@ use uuid::Uuid;
 #[sqlx(type_name = "project_category")]
 #[sqlx(rename_all = "snake_case")]
 pub enum ProjectCategory {
-    General,
-    Stage,
-    Cooking,
-    Food,
+    GeneralOnline,
+    GeneralPhysical,
+    StageOnline,
+    StagePhysical,
+    CookingPhysical,
+    FoodPhysical,
 }
 
 bitflags::bitflags! {

--- a/sos21-domain/src/model/file_distribution/distributed_file.rs
+++ b/sos21-domain/src/model/file_distribution/distributed_file.rs
@@ -43,7 +43,7 @@ mod tests {
     fn test_visibility_general() {
         let user = test_model::new_general_user();
         let operator = test_model::new_operator_user();
-        let project = test_model::new_general_project(user.id().clone());
+        let project = test_model::new_general_online_project(user.id().clone());
         let files = FileDistributionFiles::from_sharings(vec![(
             project.id(),
             FileSharingId::from_uuid(Uuid::new_v4()),
@@ -60,7 +60,7 @@ mod tests {
     fn test_visibility_committee() {
         let user = test_model::new_committee_user();
         let operator = test_model::new_operator_user();
-        let project = test_model::new_general_project(user.id().clone());
+        let project = test_model::new_general_online_project(user.id().clone());
         let files = FileDistributionFiles::from_sharings(vec![(
             project.id(),
             FileSharingId::from_uuid(Uuid::new_v4()),

--- a/sos21-domain/src/model/file_sharing.rs
+++ b/sos21-domain/src/model/file_sharing.rs
@@ -414,13 +414,13 @@ mod tests {
         use crate::model::project_query::{ProjectQuery, ProjectQueryConjunction};
 
         let query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
-            category: Some(ProjectCategory::General),
+            category: Some(ProjectCategory::GeneralOnline),
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         }])
         .unwrap();
         let scope = FileSharingScope::ProjectQuery(query);
         let sharing = FileSharing::new(test_model::new_file_id(), scope);
-        let project = test_model::new_general_project(test_model::new_user_id());
+        let project = test_model::new_general_online_project(test_model::new_user_id());
         assert!(sharing.to_witness_with_project(&project).is_ok());
     }
 
@@ -433,7 +433,7 @@ mod tests {
         let query = ProjectQuery::from_conjunctions(vec![]).unwrap();
         let scope = FileSharingScope::ProjectQuery(query);
         let sharing = FileSharing::new(test_model::new_file_id(), scope);
-        let project = test_model::new_general_project(test_model::new_user_id());
+        let project = test_model::new_general_online_project(test_model::new_user_id());
         assert!(matches!(
             sharing
                 .to_witness_with_project(&project)
@@ -451,7 +451,7 @@ mod tests {
             test_model::new_file_id(),
             FileSharingScope::Project(test_model::new_project_id()),
         );
-        let project = test_model::new_general_project(test_model::new_user_id());
+        let project = test_model::new_general_online_project(test_model::new_user_id());
         assert!(matches!(
             sharing
                 .to_witness_with_project(&project)
@@ -473,7 +473,7 @@ mod tests {
         let owner_id = test_model::new_user_id();
         let answer = test_model::new_form_answer(
             owner_id.clone(),
-            &test_model::new_general_project(owner_id.clone()),
+            &test_model::new_general_online_project(owner_id.clone()),
             &form,
         );
         assert!(matches!(

--- a/sos21-domain/src/model/form.rs
+++ b/sos21-domain/src/model/form.rs
@@ -396,7 +396,7 @@ mod tests {
     #[test]
     fn test_visibility_general_via_project() {
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let tautology_query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
             category: None,
@@ -485,9 +485,9 @@ mod tests {
     #[tokio::test]
     async fn test_answer_not_targeted() {
         let user = test_model::new_general_user();
-        let project = test_model::new_stage_project(user.id().clone());
+        let project = test_model::new_stage_online_project(user.id().clone());
         let query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
-            category: Some(ProjectCategory::General),
+            category: Some(ProjectCategory::GeneralOnline),
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         }])
         .unwrap();
@@ -509,7 +509,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_already_answered() {
         let user = test_model::new_general_user();
-        let project = test_model::new_stage_project(user.id().clone());
+        let project = test_model::new_stage_online_project(user.id().clone());
         let query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
             category: None,
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
@@ -535,7 +535,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_ok() {
         let user = test_model::new_general_user();
-        let project = test_model::new_stage_project(user.id().clone());
+        let project = test_model::new_stage_online_project(user.id().clone());
         let query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
             category: None,
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),

--- a/sos21-domain/src/model/form/condition.rs
+++ b/sos21-domain/src/model/form/condition.rs
@@ -128,11 +128,11 @@ mod tests {
             excludes: FormConditionProjectSet::from_projects(vec![]).unwrap(),
         };
 
-        let project1 = test_model::new_general_project(test_model::new_user_id());
+        let project1 = test_model::new_general_online_project(test_model::new_user_id());
         assert!(condition.check(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_exclude_tautology() {
-        let project1 = test_model::new_general_project(test_model::new_user_id());
+        let project1 = test_model::new_general_online_project(test_model::new_user_id());
 
         let conj = ProjectQueryConjunction {
             category: None,
@@ -159,7 +159,7 @@ mod tests {
 
         assert!(!condition.check(&project1));
 
-        let project2 = test_model::new_general_project(test_model::new_user_id());
+        let project2 = test_model::new_general_online_project(test_model::new_user_id());
         assert!(condition.check(&project2));
     }
 
@@ -172,11 +172,11 @@ mod tests {
             excludes: FormConditionProjectSet::from_projects(vec![]).unwrap(),
         };
 
-        let project1 = test_model::new_general_project(test_model::new_user_id());
+        let project1 = test_model::new_general_online_project(test_model::new_user_id());
         assert!(!condition.check(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_include_contradiction() {
-        let project1 = test_model::new_general_project(test_model::new_user_id());
+        let project1 = test_model::new_general_online_project(test_model::new_user_id());
 
         let query = ProjectQuery::from_conjunctions(vec![]).unwrap();
         let condition = FormCondition {
@@ -198,7 +198,7 @@ mod tests {
         };
 
         assert!(condition.check(&project1));
-        let project2 = test_model::new_general_project(test_model::new_user_id());
+        let project2 = test_model::new_general_online_project(test_model::new_user_id());
         assert!(!condition.check(&project2));
     }
 
@@ -206,12 +206,12 @@ mod tests {
     fn test_include_exclude() {
         let project1 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[],
         );
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic],
         );
 

--- a/sos21-domain/src/model/form_answer.rs
+++ b/sos21-domain/src/model/form_answer.rs
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn test_visibility_general() {
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let form = test_model::new_form(operator.id().clone());
         let form_answer = test_model::new_form_answer(user.id().clone(), &user_project, &form);
@@ -275,7 +275,7 @@ mod tests {
     #[test]
     fn test_visibility_committee() {
         let user = test_model::new_committee_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let form = test_model::new_form(operator.id().clone());
         let form_answer = test_model::new_form_answer(user.id().clone(), &user_project, &form);
@@ -285,7 +285,7 @@ mod tests {
     #[test]
     fn test_visibility_operator() {
         let user = test_model::new_operator_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let form = test_model::new_form(operator.id().clone());
         let form_answer = test_model::new_form_answer(user.id().clone(), &user_project, &form);
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn test_visibility_general_via_owning_project() {
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let form = test_model::new_form(operator.id().clone());
         let form_answer = test_model::new_form_answer(user.id().clone(), &user_project, &form);
@@ -306,7 +306,7 @@ mod tests {
     fn test_visibility_general_via_non_owning_project() {
         let user = test_model::new_general_user();
         let operator = test_model::new_operator_user();
-        let operator_project = test_model::new_general_project(operator.id().clone());
+        let operator_project = test_model::new_general_online_project(operator.id().clone());
         let form = test_model::new_form(operator.id().clone());
         let form_answer = test_model::new_form_answer(user.id().clone(), &operator_project, &form);
         assert!(!form_answer.is_visible_to_with_project(&user, &operator_project));
@@ -318,7 +318,7 @@ mod tests {
         use crate::model::form_answer::item as answer_item;
 
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
 
         let (items, answer_items, item_id) = {
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn test_set_items_general_after_period() {
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let period = test_model::new_form_period_to_now();
         let form = test_model::new_form_with_period(operator.id().clone(), period);

--- a/sos21-domain/src/model/pending_project.rs
+++ b/sos21-domain/src/model/pending_project.rs
@@ -349,7 +349,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_already_project_owner() {
         let mut owner = test_model::new_general_user();
-        let project = test_model::new_general_project(owner.id().clone());
+        let project = test_model::new_general_online_project(owner.id().clone());
         owner.assign_project_owner(&project).unwrap();
 
         assert_eq!(
@@ -361,7 +361,7 @@ mod tests {
                 test_model::mock_project_group_name(),
                 test_model::mock_project_kana_group_name(),
                 test_model::mock_project_description(),
-                ProjectCategory::General,
+                ProjectCategory::GeneralOnline,
                 ProjectAttributes::from_attributes(vec![]).unwrap()
             )
             .unwrap_err()
@@ -374,8 +374,10 @@ mod tests {
     async fn test_new_already_project_subowner() {
         let mut owner = test_model::new_general_user();
         let user = test_model::new_general_user();
-        let project =
-            test_model::new_general_project_with_subowner(user.id().clone(), owner.id().clone());
+        let project = test_model::new_general_online_project_with_subowner(
+            user.id().clone(),
+            owner.id().clone(),
+        );
         owner.assign_project_subowner(&project).unwrap();
 
         assert_eq!(
@@ -387,7 +389,7 @@ mod tests {
                 test_model::mock_project_group_name(),
                 test_model::mock_project_kana_group_name(),
                 test_model::mock_project_description(),
-                ProjectCategory::General,
+                ProjectCategory::GeneralOnline,
                 ProjectAttributes::from_attributes(vec![]).unwrap()
             )
             .unwrap_err()
@@ -399,7 +401,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_already_pending_project_owner() {
         let mut owner = test_model::new_general_user();
-        let pending_project = test_model::new_general_pending_project(owner.id().clone());
+        let pending_project = test_model::new_general_online_pending_project(owner.id().clone());
         owner
             .assign_pending_project_owner(&pending_project)
             .unwrap();
@@ -413,7 +415,7 @@ mod tests {
                 test_model::mock_project_group_name(),
                 test_model::mock_project_kana_group_name(),
                 test_model::mock_project_description(),
-                ProjectCategory::General,
+                ProjectCategory::GeneralOnline,
                 ProjectAttributes::from_attributes(vec![]).unwrap()
             )
             .unwrap_err()

--- a/sos21-domain/src/model/pending_project.rs
+++ b/sos21-domain/src/model/pending_project.rs
@@ -2,8 +2,8 @@ use crate::context::ConfigContext;
 use crate::model::date_time::DateTime;
 use crate::model::permissions::Permissions;
 use crate::model::project::{
-    ProjectAttributes, ProjectCategory, ProjectDescription, ProjectGroupName, ProjectKanaGroupName,
-    ProjectKanaName, ProjectName,
+    ProjectAttribute, ProjectAttributes, ProjectCategory, ProjectDescription, ProjectGroupName,
+    ProjectKanaGroupName, ProjectKanaName, ProjectName,
 };
 use crate::model::user::{self, User, UserAssignment, UserId};
 
@@ -50,6 +50,7 @@ pub enum NewPendingProjectErrorKind {
     AlreadyProjectSubownerOwner,
     AlreadyPendingProjectOwnerOwner,
     OutOfCreationPeriod,
+    ArtisticStageProject,
 }
 
 #[derive(Debug, Clone, Error)]
@@ -103,6 +104,14 @@ impl PendingProject {
                 }
             };
             return Err(NewPendingProjectError { kind });
+        }
+
+        if (category == ProjectCategory::StageOnline || category == ProjectCategory::StagePhysical)
+            && attributes.contains(ProjectAttribute::Artistic)
+        {
+            return Err(NewPendingProjectError {
+                kind: NewPendingProjectErrorKind::ArtisticStageProject,
+            });
         }
 
         Ok(PendingProject::from_content(

--- a/sos21-domain/src/model/project.rs
+++ b/sos21-domain/src/model/project.rs
@@ -490,14 +490,14 @@ mod tests {
     #[test]
     fn test_visibility_general_owner() {
         let user = test_model::new_general_user();
-        let project = test_model::new_general_project(user.id().clone());
+        let project = test_model::new_general_online_project(user.id().clone());
         assert!(project.is_visible_to(&user));
     }
 
     #[test]
     fn test_visibility_general_subowner() {
         let user = test_model::new_general_user();
-        let project = test_model::new_general_project_with_subowner(
+        let project = test_model::new_general_online_project_with_subowner(
             test_model::new_user_id(),
             user.id().clone(),
         );
@@ -508,7 +508,7 @@ mod tests {
     fn test_visibility_general_other() {
         let user = test_model::new_general_user();
         let other = test_model::new_general_user();
-        let project = test_model::new_general_project(other.id().clone());
+        let project = test_model::new_general_online_project(other.id().clone());
         assert!(!project.is_visible_to(&user));
     }
 
@@ -516,7 +516,7 @@ mod tests {
     fn test_visibility_committee_other() {
         let user = test_model::new_committee_user();
         let other = test_model::new_general_user();
-        let project = test_model::new_general_project(other.id().clone());
+        let project = test_model::new_general_online_project(other.id().clone());
         assert!(project.is_visible_to(&user));
     }
 
@@ -524,7 +524,7 @@ mod tests {
     fn test_visibility_operator_other() {
         let user = test_model::new_operator_user();
         let other = test_model::new_general_user();
-        let project = test_model::new_general_project(other.id().clone());
+        let project = test_model::new_general_online_project(other.id().clone());
         assert!(project.is_visible_to(&user));
     }
 
@@ -532,7 +532,7 @@ mod tests {
     async fn test_new_ok() {
         let owner = test_model::new_general_user();
         let subowner = test_model::new_general_user();
-        let pending_project = test_model::new_general_pending_project(owner.id().clone());
+        let pending_project = test_model::new_general_online_pending_project(owner.id().clone());
 
         let app = crate::test::build_mock_app()
             .users(vec![owner.clone(), subowner.clone()])
@@ -550,7 +550,7 @@ mod tests {
     async fn test_new_not_answered() {
         let owner = test_model::new_general_user();
         let subowner = test_model::new_general_user();
-        let pending_project = test_model::new_general_pending_project(owner.id().clone());
+        let pending_project = test_model::new_general_online_pending_project(owner.id().clone());
 
         let operator = test_model::new_general_user();
         let registration_form = test_model::new_registration_form(operator.id().clone());
@@ -571,7 +571,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_same_owner_subowner() {
         let owner = test_model::new_general_user();
-        let pending_project = test_model::new_general_pending_project(owner.id().clone());
+        let pending_project = test_model::new_general_online_pending_project(owner.id().clone());
 
         let app = crate::test::build_mock_app()
             .users(vec![owner.clone()])
@@ -589,10 +589,10 @@ mod tests {
     async fn test_new_already_project_owner() {
         let owner = test_model::new_general_user();
         let mut subowner = test_model::new_general_user();
-        let project = test_model::new_general_project(subowner.id().clone());
+        let project = test_model::new_general_online_project(subowner.id().clone());
         subowner.assign_project_owner(&project).unwrap();
 
-        let pending_project = test_model::new_general_pending_project(owner.id().clone());
+        let pending_project = test_model::new_general_online_pending_project(owner.id().clone());
 
         let app = crate::test::build_mock_app()
             .users(vec![owner.clone(), subowner.clone()])
@@ -612,11 +612,13 @@ mod tests {
         let owner = test_model::new_general_user();
         let user = test_model::new_general_user();
         let mut subowner = test_model::new_general_user();
-        let project =
-            test_model::new_general_project_with_subowner(user.id().clone(), subowner.id().clone());
+        let project = test_model::new_general_online_project_with_subowner(
+            user.id().clone(),
+            subowner.id().clone(),
+        );
         subowner.assign_project_subowner(&project).unwrap();
 
-        let pending_project = test_model::new_general_pending_project(owner.id().clone());
+        let pending_project = test_model::new_general_online_pending_project(owner.id().clone());
 
         let app = crate::test::build_mock_app()
             .users(vec![user, owner.clone(), subowner.clone()])
@@ -635,12 +637,13 @@ mod tests {
     async fn test_new_already_pending_project_owner() {
         let owner = test_model::new_general_user();
         let mut subowner = test_model::new_general_user();
-        let pending_project1 = test_model::new_general_pending_project(subowner.id().clone());
+        let pending_project1 =
+            test_model::new_general_online_pending_project(subowner.id().clone());
         subowner
             .assign_pending_project_owner(&pending_project1)
             .unwrap();
 
-        let pending_project2 = test_model::new_general_pending_project(owner.id().clone());
+        let pending_project2 = test_model::new_general_online_pending_project(owner.id().clone());
 
         let app = crate::test::build_mock_app()
             .users(vec![owner.clone(), subowner.clone()])

--- a/sos21-domain/src/model/project.rs
+++ b/sos21-domain/src/model/project.rs
@@ -289,7 +289,7 @@ impl Project {
 
     pub fn kind(&self) -> ProjectKind {
         ProjectKind {
-            is_cooking: self.content.category == ProjectCategory::Cooking,
+            is_cooking: self.content.category == ProjectCategory::CookingPhysical,
             is_outdoor: self.content.attributes.contains(ProjectAttribute::Outdoor),
         }
     }

--- a/sos21-domain/src/model/project/category.rs
+++ b/sos21-domain/src/model/project/category.rs
@@ -5,19 +5,23 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ProjectCategory {
-    General,
-    Stage,
-    Cooking,
-    Food,
+    GeneralOnline,
+    GeneralPhysical,
+    StageOnline,
+    StagePhysical,
+    CookingPhysical,
+    FoodPhysical,
 }
 
 impl ProjectCategory {
     pub fn enumerate() -> impl Iterator<Item = ProjectCategory> {
         [
-            ProjectCategory::General,
-            ProjectCategory::Stage,
-            ProjectCategory::Cooking,
-            ProjectCategory::Food,
+            ProjectCategory::GeneralOnline,
+            ProjectCategory::GeneralPhysical,
+            ProjectCategory::StageOnline,
+            ProjectCategory::StagePhysical,
+            ProjectCategory::CookingPhysical,
+            ProjectCategory::FoodPhysical,
         ]
         .iter()
         .copied()
@@ -34,10 +38,12 @@ impl FromStr for ProjectCategory {
     type Err = ParseCategoryError;
     fn from_str(s: &str) -> Result<ProjectCategory, Self::Err> {
         match s {
-            "general" | "General" => Ok(ProjectCategory::General),
-            "stage" | "Stage" => Ok(ProjectCategory::Stage),
-            "cooking" | "Cooking" => Ok(ProjectCategory::Cooking),
-            "food" | "Food" => Ok(ProjectCategory::Food),
+            "general_online" | "GeneralOnline" => Ok(ProjectCategory::GeneralOnline),
+            "general_physical" | "GeneralPhysical" => Ok(ProjectCategory::GeneralPhysical),
+            "stage_online" | "Stage_online" => Ok(ProjectCategory::StageOnline),
+            "stage_physical" | "StagePhysical" => Ok(ProjectCategory::StagePhysical),
+            "cooking_physical" | "CookingPhysical" => Ok(ProjectCategory::CookingPhysical),
+            "food_physical" | "FoodPhysical" => Ok(ProjectCategory::FoodPhysical),
             _ => Err(ParseCategoryError { _priv: () }),
         }
     }

--- a/sos21-domain/src/model/project_query.rs
+++ b/sos21-domain/src/model/project_query.rs
@@ -132,11 +132,11 @@ mod tests {
             category: None,
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         };
-        let project1 = test_model::new_general_project(test_model::new_user_id());
+        let project1 = test_model::new_general_online_project(test_model::new_user_id());
         assert!(conj.check_project(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -152,11 +152,12 @@ mod tests {
             category: None,
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         };
-        let pending_project = test_model::new_general_pending_project(test_model::new_user_id());
+        let pending_project =
+            test_model::new_general_online_pending_project(test_model::new_user_id());
         assert!(conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -175,19 +176,19 @@ mod tests {
         };
         let project1 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[],
         );
         assert!(!conj.check_project(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Artistic, ProjectAttribute::Committee],
         );
         assert!(conj.check_project(&project2));
         let project3 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -197,7 +198,7 @@ mod tests {
         assert!(conj.check_project(&project3));
         let project4 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(!conj.check_project(&project4));
@@ -212,19 +213,19 @@ mod tests {
         };
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[],
         );
         assert!(!conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Artistic, ProjectAttribute::Committee],
         );
         assert!(conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -234,7 +235,7 @@ mod tests {
         assert!(conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(!conj.check_pending_project(&pending_project));
@@ -252,19 +253,19 @@ mod tests {
         };
         let project1 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[],
         );
         assert!(!conj.check_project(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Artistic, ProjectAttribute::Committee],
         );
         assert!(conj.check_project(&project2));
         let project3 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -274,7 +275,7 @@ mod tests {
         assert!(conj.check_project(&project3));
         let project4 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Artistic, ProjectAttribute::Academic],
         );
         assert!(!conj.check_project(&project4));
@@ -292,19 +293,19 @@ mod tests {
         };
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[],
         );
         assert!(!conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Artistic, ProjectAttribute::Committee],
         );
         assert!(conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -314,7 +315,7 @@ mod tests {
         assert!(conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Artistic, ProjectAttribute::Academic],
         );
         assert!(!conj.check_pending_project(&pending_project));
@@ -323,26 +324,30 @@ mod tests {
     #[test]
     fn test_conj_category() {
         let conj = ProjectQueryConjunction {
-            category: Some(ProjectCategory::General),
+            category: Some(ProjectCategory::GeneralOnline),
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         };
-        assert!(conj.check_project(&test_model::new_general_project(test_model::new_user_id())));
-        assert!(!conj.check_project(&test_model::new_stage_project(test_model::new_user_id())));
+        assert!(conj.check_project(&test_model::new_general_online_project(
+            test_model::new_user_id()
+        )));
+        assert!(!conj.check_project(&test_model::new_stage_online_project(
+            test_model::new_user_id()
+        )));
     }
 
     #[test]
     fn test_pending_project_conj_category() {
         let conj = ProjectQueryConjunction {
-            category: Some(ProjectCategory::General),
+            category: Some(ProjectCategory::GeneralOnline),
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         };
         assert!(
-            conj.check_pending_project(&test_model::new_general_pending_project(
+            conj.check_pending_project(&test_model::new_general_online_pending_project(
                 test_model::new_user_id()
             ))
         );
         assert!(
-            !conj.check_pending_project(&test_model::new_stage_pending_project(
+            !conj.check_pending_project(&test_model::new_stage_online_pending_project(
                 test_model::new_user_id()
             ))
         );
@@ -351,7 +356,7 @@ mod tests {
     #[test]
     fn test_conj_complex() {
         let conj = ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![
                 ProjectAttribute::Academic,
                 ProjectAttribute::Committee,
@@ -360,25 +365,25 @@ mod tests {
         };
         let project1 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[],
         );
         assert!(!conj.check_project(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(!conj.check_project(&project2));
         let project3 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::Stage,
+            ProjectCategory::StageOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(conj.check_project(&project3));
         let project4 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::Stage,
+            ProjectCategory::StageOnline,
             &[ProjectAttribute::Academic],
         );
         assert!(!conj.check_project(&project4));
@@ -387,30 +392,31 @@ mod tests {
     #[test]
     fn test_pending_project_conj_complex() {
         let conj = ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![
                 ProjectAttribute::Academic,
                 ProjectAttribute::Committee,
             ])
             .unwrap(),
         };
-        let pending_project = test_model::new_general_pending_project(test_model::new_user_id());
+        let pending_project =
+            test_model::new_general_online_pending_project(test_model::new_user_id());
         assert!(!conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(!conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::Stage,
+            ProjectCategory::StageOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(conj.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::Stage,
+            ProjectCategory::StageOnline,
             &[ProjectAttribute::Academic],
         );
         assert!(!conj.check_pending_project(&pending_project));
@@ -425,13 +431,13 @@ mod tests {
         let query = ProjectQuery::from_conjunctions(vec![conj]).unwrap();
         let project1 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[],
         );
         assert!(query.check_project(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -448,11 +454,12 @@ mod tests {
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         };
         let query = ProjectQuery::from_conjunctions(vec![conj]).unwrap();
-        let pending_project = test_model::new_general_pending_project(test_model::new_user_id());
+        let pending_project =
+            test_model::new_general_online_pending_project(test_model::new_user_id());
         assert!(query.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -467,13 +474,13 @@ mod tests {
         let query = ProjectQuery::from_conjunctions(vec![]).unwrap();
         let project1 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[],
         );
         assert!(!query.check_project(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -486,11 +493,12 @@ mod tests {
     #[test]
     fn test_pending_project_contradiction() {
         let query = ProjectQuery::from_conjunctions(vec![]).unwrap();
-        let pending_project = test_model::new_general_pending_project(test_model::new_user_id());
+        let pending_project =
+            test_model::new_general_online_pending_project(test_model::new_user_id());
         assert!(!query.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[
                 ProjectAttribute::Artistic,
                 ProjectAttribute::Academic,
@@ -503,7 +511,7 @@ mod tests {
     #[test]
     fn test_complex() {
         let conj1 = ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![ProjectAttribute::Academic])
                 .unwrap(),
         };
@@ -518,25 +526,25 @@ mod tests {
         let query = ProjectQuery::from_conjunctions(vec![conj1, conj2]).unwrap();
         let project1 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic],
         );
         assert!(!query.check_project(&project1));
         let project2 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::Stage,
+            ProjectCategory::StageOnline,
             &[ProjectAttribute::Academic],
         );
         assert!(query.check_project(&project2));
         let project3 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::Stage,
+            ProjectCategory::StageOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(query.check_project(&project3));
         let project4 = test_model::new_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(query.check_project(&project4));
@@ -545,7 +553,7 @@ mod tests {
     #[test]
     fn test_pending_project_complex() {
         let conj1 = ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![ProjectAttribute::Academic])
                 .unwrap(),
         };
@@ -560,25 +568,25 @@ mod tests {
         let query = ProjectQuery::from_conjunctions(vec![conj1, conj2]).unwrap();
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic],
         );
         assert!(!query.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::Stage,
+            ProjectCategory::StageOnline,
             &[ProjectAttribute::Academic],
         );
         assert!(query.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::Stage,
+            ProjectCategory::StageOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(query.check_pending_project(&pending_project));
         let pending_project = test_model::new_pending_project_with_attributes(
             test_model::new_user_id(),
-            ProjectCategory::General,
+            ProjectCategory::GeneralOnline,
             &[ProjectAttribute::Academic, ProjectAttribute::Committee],
         );
         assert!(query.check_pending_project(&pending_project));
@@ -589,13 +597,13 @@ mod tests {
         use std::collections::HashSet;
 
         let conj1 = ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![ProjectAttribute::Academic])
                 .unwrap(),
         };
         assert_eq!(
             conj1.possible_categories().collect::<Vec<_>>(),
-            vec![ProjectCategory::Stage]
+            vec![ProjectCategory::StageOnline]
         );
         let conj2 = ProjectQueryConjunction {
             category: None,
@@ -613,12 +621,12 @@ mod tests {
         use std::collections::HashSet;
 
         let conj1 = ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![ProjectAttribute::Academic])
                 .unwrap(),
         };
         let conj2 = ProjectQueryConjunction {
-            category: Some(ProjectCategory::Food),
+            category: Some(ProjectCategory::FoodPhysical),
             attributes: ProjectAttributes::from_attributes(vec![
                 ProjectAttribute::Academic,
                 ProjectAttribute::Committee,
@@ -628,14 +636,14 @@ mod tests {
         let query1 = ProjectQuery::from_conjunctions(vec![conj1, conj2]).unwrap();
         assert_eq!(
             query1.possible_categories().collect::<HashSet<_>>(),
-            [ProjectCategory::Stage, ProjectCategory::Food]
+            [ProjectCategory::StageOnline, ProjectCategory::FoodPhysical]
                 .iter()
                 .copied()
                 .collect::<HashSet<_>>()
         );
 
         let conj1 = ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![ProjectAttribute::Academic])
                 .unwrap(),
         };

--- a/sos21-domain/src/model/registration_form.rs
+++ b/sos21-domain/src/model/registration_form.rs
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn test_visibility_general_via_matching_project() {
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let tautology_query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
             category: None,
@@ -206,7 +206,7 @@ mod tests {
     fn test_visibility_general_via_matching_non_owner_project() {
         let user = test_model::new_general_user();
         let operator = test_model::new_operator_user();
-        let operator_project = test_model::new_general_project(operator.id().clone());
+        let operator_project = test_model::new_general_online_project(operator.id().clone());
         let tautology_query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
             category: None,
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
@@ -220,10 +220,10 @@ mod tests {
     #[test]
     fn test_visibility_general_via_non_matching_project() {
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         }])
         .unwrap();
@@ -235,7 +235,8 @@ mod tests {
     #[test]
     fn test_visibility_general_via_matching_pending_project() {
         let user = test_model::new_general_user();
-        let user_pending_project = test_model::new_general_pending_project(user.id().clone());
+        let user_pending_project =
+            test_model::new_general_online_pending_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let tautology_query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
             category: None,
@@ -252,7 +253,7 @@ mod tests {
         let user = test_model::new_general_user();
         let operator = test_model::new_operator_user();
         let operator_pending_project =
-            test_model::new_general_pending_project(operator.id().clone());
+            test_model::new_general_online_pending_project(operator.id().clone());
         let tautology_query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
             category: None,
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
@@ -268,10 +269,11 @@ mod tests {
     #[test]
     fn test_visibility_general_via_non_matching_pending_project() {
         let user = test_model::new_general_user();
-        let user_pending_project = test_model::new_general_pending_project(user.id().clone());
+        let user_pending_project =
+            test_model::new_general_online_pending_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let query = ProjectQuery::from_conjunctions(vec![ProjectQueryConjunction {
-            category: Some(ProjectCategory::Stage),
+            category: Some(ProjectCategory::StageOnline),
             attributes: ProjectAttributes::from_attributes(vec![]).unwrap(),
         }])
         .unwrap();

--- a/sos21-domain/src/model/registration_form_answer.rs
+++ b/sos21-domain/src/model/registration_form_answer.rs
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn test_visibility_general() {
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let registration_form = test_model::new_registration_form(operator.id().clone());
         let registration_form_answer = test_model::new_registration_form_answer_with_project(
@@ -372,7 +372,7 @@ mod tests {
     #[test]
     fn test_visibility_committee() {
         let user = test_model::new_committee_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let registration_form = test_model::new_registration_form(operator.id().clone());
         let registration_form_answer = test_model::new_registration_form_answer_with_project(
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn test_visibility_operator() {
         let user = test_model::new_operator_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let registration_form = test_model::new_registration_form(operator.id().clone());
         let registration_form_answer = test_model::new_registration_form_answer_with_project(
@@ -400,7 +400,7 @@ mod tests {
     #[test]
     fn test_visibility_general_via_owning_project() {
         let user = test_model::new_general_user();
-        let user_project = test_model::new_general_project(user.id().clone());
+        let user_project = test_model::new_general_online_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let registration_form = test_model::new_registration_form(operator.id().clone());
         let registration_form_answer = test_model::new_registration_form_answer_with_project(
@@ -414,7 +414,8 @@ mod tests {
     #[test]
     fn test_visibility_general_via_owning_pending_project() {
         let user = test_model::new_general_user();
-        let user_pending_project = test_model::new_general_pending_project(user.id().clone());
+        let user_pending_project =
+            test_model::new_general_online_pending_project(user.id().clone());
         let operator = test_model::new_operator_user();
         let registration_form = test_model::new_registration_form(operator.id().clone());
         let registration_form_answer =
@@ -431,7 +432,7 @@ mod tests {
     fn test_visibility_general_via_non_owning_project() {
         let user = test_model::new_general_user();
         let operator = test_model::new_operator_user();
-        let operator_project = test_model::new_general_project(operator.id().clone());
+        let operator_project = test_model::new_general_online_project(operator.id().clone());
         let registration_form = test_model::new_registration_form(operator.id().clone());
         let registration_form_answer = test_model::new_registration_form_answer_with_project(
             user.id().clone(),
@@ -446,7 +447,7 @@ mod tests {
         let user = test_model::new_general_user();
         let operator = test_model::new_operator_user();
         let operator_pending_project =
-            test_model::new_general_pending_project(operator.id().clone());
+            test_model::new_general_online_pending_project(operator.id().clone());
         let registration_form = test_model::new_registration_form(operator.id().clone());
         let registration_form_answer =
             test_model::new_registration_form_answer_with_pending_project(

--- a/sos21-domain/src/test/model/pending_project.rs
+++ b/sos21-domain/src/test/model/pending_project.rs
@@ -41,10 +41,18 @@ pub fn new_pending_project(author_id: UserId, category: ProjectCategory) -> Pend
     new_pending_project_with_attributes(author_id, category, &[])
 }
 
-pub fn new_general_pending_project(author_id: UserId) -> PendingProject {
-    new_pending_project(author_id, ProjectCategory::General)
+pub fn new_general_online_pending_project(author_id: UserId) -> PendingProject {
+    new_pending_project(author_id, ProjectCategory::GeneralOnline)
 }
 
-pub fn new_stage_pending_project(author_id: UserId) -> PendingProject {
-    new_pending_project(author_id, ProjectCategory::Stage)
+pub fn new_general_physical_pending_project(author_id: UserId) -> PendingProject {
+    new_pending_project(author_id, ProjectCategory::GeneralPhysical)
+}
+
+pub fn new_stage_online_pending_project(author_id: UserId) -> PendingProject {
+    new_pending_project(author_id, ProjectCategory::StageOnline)
+}
+
+pub fn new_stage_physical_pending_project(author_id: UserId) -> PendingProject {
+    new_pending_project(author_id, ProjectCategory::StagePhysical)
 }

--- a/sos21-domain/src/test/model/project.rs
+++ b/sos21-domain/src/test/model/project.rs
@@ -103,18 +103,37 @@ pub fn new_project(owner_id: UserId, category: ProjectCategory) -> Project {
     new_project_with_attributes(owner_id, category, &[])
 }
 
-pub fn new_general_project(owner_id: UserId) -> Project {
-    new_project(owner_id, ProjectCategory::General)
+pub fn new_general_online_project(owner_id: UserId) -> Project {
+    new_project(owner_id, ProjectCategory::GeneralOnline)
 }
 
-pub fn new_stage_project(owner_id: UserId) -> Project {
-    new_project(owner_id, ProjectCategory::Stage)
+pub fn new_general_physical_project(owner_id: UserId) -> Project {
+    new_project(owner_id, ProjectCategory::GeneralPhysical)
 }
 
-pub fn new_general_project_with_subowner(owner_id: UserId, subowner_id: UserId) -> Project {
-    new_project_with_subowner(owner_id, subowner_id, ProjectCategory::General)
+pub fn new_stage_online_project(owner_id: UserId) -> Project {
+    new_project(owner_id, ProjectCategory::StageOnline)
 }
 
-pub fn new_stage_project_with_subowner(owner_id: UserId, subowner_id: UserId) -> Project {
-    new_project_with_subowner(owner_id, subowner_id, ProjectCategory::Stage)
+pub fn new_stage_physical_project(owner_id: UserId) -> Project {
+    new_project(owner_id, ProjectCategory::StagePhysical)
+}
+
+pub fn new_general_online_project_with_subowner(owner_id: UserId, subowner_id: UserId) -> Project {
+    new_project_with_subowner(owner_id, subowner_id, ProjectCategory::GeneralOnline)
+}
+
+pub fn new_general_physical_project_with_subowner(
+    owner_id: UserId,
+    subowner_id: UserId,
+) -> Project {
+    new_project_with_subowner(owner_id, subowner_id, ProjectCategory::GeneralPhysical)
+}
+
+pub fn new_stage_online_project_with_subowner(owner_id: UserId, subowner_id: UserId) -> Project {
+    new_project_with_subowner(owner_id, subowner_id, ProjectCategory::StageOnline)
+}
+
+pub fn new_stage_physical_project_with_subowner(owner_id: UserId, subowner_id: UserId) -> Project {
+    new_project_with_subowner(owner_id, subowner_id, ProjectCategory::StagePhysical)
 }

--- a/sos21-gateway/database/src/project_repository.rs
+++ b/sos21-gateway/database/src/project_repository.rs
@@ -158,10 +158,12 @@ fn from_project(project: Project) -> data::project::Project {
 
 pub fn from_project_category(category: ProjectCategory) -> data::project::ProjectCategory {
     match category {
-        ProjectCategory::General => data::project::ProjectCategory::General,
-        ProjectCategory::Stage => data::project::ProjectCategory::Stage,
-        ProjectCategory::Cooking => data::project::ProjectCategory::Cooking,
-        ProjectCategory::Food => data::project::ProjectCategory::Food,
+        ProjectCategory::GeneralOnline => data::project::ProjectCategory::GeneralOnline,
+        ProjectCategory::GeneralPhysical => data::project::ProjectCategory::GeneralPhysical,
+        ProjectCategory::StageOnline => data::project::ProjectCategory::StageOnline,
+        ProjectCategory::StagePhysical => data::project::ProjectCategory::StagePhysical,
+        ProjectCategory::CookingPhysical => data::project::ProjectCategory::CookingPhysical,
+        ProjectCategory::FoodPhysical => data::project::ProjectCategory::FoodPhysical,
     }
 }
 
@@ -179,10 +181,12 @@ pub fn from_project_attributes(attributes: &ProjectAttributes) -> data::project:
 
 pub fn to_project_category(category: data::project::ProjectCategory) -> ProjectCategory {
     match category {
-        data::project::ProjectCategory::General => ProjectCategory::General,
-        data::project::ProjectCategory::Stage => ProjectCategory::Stage,
-        data::project::ProjectCategory::Cooking => ProjectCategory::Cooking,
-        data::project::ProjectCategory::Food => ProjectCategory::Food,
+        data::project::ProjectCategory::GeneralOnline => ProjectCategory::GeneralOnline,
+        data::project::ProjectCategory::GeneralPhysical => ProjectCategory::GeneralPhysical,
+        data::project::ProjectCategory::StageOnline => ProjectCategory::StageOnline,
+        data::project::ProjectCategory::StagePhysical => ProjectCategory::StagePhysical,
+        data::project::ProjectCategory::CookingPhysical => ProjectCategory::CookingPhysical,
+        data::project::ProjectCategory::FoodPhysical => ProjectCategory::FoodPhysical,
     }
 }
 

--- a/sos21-use-case/src/answer_form.rs
+++ b/sos21-use-case/src/answer_form.rs
@@ -130,8 +130,10 @@ mod tests {
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
         let other = test::model::new_operator_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
         let form = test::model::new_form(other.id().clone());
 
         let app = test::build_mock_app()
@@ -165,7 +167,7 @@ mod tests {
     async fn test_create_owner() {
         let user = test::model::new_general_user();
         let other = test::model::new_operator_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let form = test::model::new_form(other.id().clone());
 
         let app = test::build_mock_app()
@@ -199,7 +201,7 @@ mod tests {
     async fn test_create_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_operator_user();
-        let project = test::model::new_general_project(other.id().clone());
+        let project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(other.id().clone());
 
         let app = test::build_mock_app()
@@ -228,7 +230,7 @@ mod tests {
     async fn test_invalid() {
         let user = test::model::new_general_user();
         let other = test::model::new_operator_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let form = test::model::new_form(other.id().clone());
 
         let app = test::build_mock_app()
@@ -259,7 +261,7 @@ mod tests {
     async fn test_file_share() {
         let user = test::model::new_general_user();
         let other = test::model::new_operator_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let (form, item_id) = {
             let body = item::FormItemBody::File(item::FileFormItem {

--- a/sos21-use-case/src/answer_registration_form.rs
+++ b/sos21-use-case/src/answer_registration_form.rs
@@ -142,7 +142,7 @@ mod tests {
     async fn test_create_author() {
         let user = test::model::new_general_user();
         let other = test::model::new_operator_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
 
         let app = test::build_mock_app()
@@ -178,7 +178,7 @@ mod tests {
     async fn test_create_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_operator_user();
-        let pending_project = test::model::new_general_pending_project(other.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(other.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
 
         let app = test::build_mock_app()
@@ -209,7 +209,7 @@ mod tests {
     async fn test_invalid() {
         let user = test::model::new_general_user();
         let other = test::model::new_operator_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
 
         let app = test::build_mock_app()
@@ -247,7 +247,7 @@ mod tests {
 
         let user = test::model::new_general_user();
         let operator = test::model::new_operator_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
 
         let (registration_form, item_id) = {
             let body = item::FormItemBody::File(item::FileFormItem {

--- a/sos21-use-case/src/create_project.rs
+++ b/sos21-use-case/src/create_project.rs
@@ -143,7 +143,7 @@ mod tests {
     #[tokio::test]
     async fn test_owner() {
         let user = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -164,10 +164,10 @@ mod tests {
     async fn test_already_project_owner() {
         let owner = test::model::new_general_user();
         let mut user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         user.assign_project_owner(&project).unwrap();
 
-        let pending_project = test::model::new_general_pending_project(owner.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(owner.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), owner.clone()])
@@ -189,7 +189,7 @@ mod tests {
     async fn test_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(other.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -217,13 +217,13 @@ mod tests {
     async fn test_after_other_category_period_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(other.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(other.id().clone());
         let period = test::model::new_project_creation_period_to_now();
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
             .pending_projects(vec![pending_project.clone()])
-            .project_creation_period_for(project::ProjectCategory::Stage, period)
+            .project_creation_period_for(project::ProjectCategory::StageOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -247,13 +247,13 @@ mod tests {
     async fn test_with_period_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(other.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(other.id().clone());
         let period = test::model::new_project_creation_period_from_now();
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
             .pending_projects(vec![pending_project.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -274,13 +274,13 @@ mod tests {
     async fn test_after_period_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(other.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(other.id().clone());
         let period = test::model::new_project_creation_period_to_now();
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
             .pending_projects(vec![pending_project.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -297,13 +297,13 @@ mod tests {
     async fn test_before_period_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(other.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(other.id().clone());
         let period = test::model::new_project_creation_period_with_hours_from_now(1);
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
             .pending_projects(vec![pending_project.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -320,7 +320,7 @@ mod tests {
     async fn test_other_with_registration_form_not_answered() {
         let owner = test::model::new_general_user();
         let subowner = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(owner.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(owner.id().clone());
 
         let operator = test::model::new_general_user();
         let registration_form1 = test::model::new_registration_form(operator.id().clone());
@@ -355,7 +355,7 @@ mod tests {
 
         let owner = test::model::new_general_user();
         let subowner = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(owner.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(owner.id().clone());
 
         let operator = test::model::new_general_user();
         let registration_form1 = test::model::new_registration_form(operator.id().clone());
@@ -364,7 +364,7 @@ mod tests {
             operator.id().clone(),
             project_query::ProjectQuery::from_conjunctions(vec![
                 project_query::ProjectQueryConjunction {
-                    category: Some(project::ProjectCategory::Stage),
+                    category: Some(project::ProjectCategory::StageOnline),
                     attributes: project::ProjectAttributes::from_attributes(vec![]).unwrap(),
                 },
             ])
@@ -424,7 +424,7 @@ mod tests {
 
         let owner = test::model::new_general_user();
         let subowner = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(owner.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(owner.id().clone());
 
         let operator = test::model::new_general_user();
         let registration_form = test::model::new_registration_form(operator.id().clone());

--- a/sos21-use-case/src/create_project.rs
+++ b/sos21-use-case/src/create_project.rs
@@ -15,6 +15,7 @@ pub enum Error {
     TooManyProjects,
     NotAnsweredRegistrationForm,
     SameOwnerSubowner,
+    ArtisticStageProject,
     AlreadyProjectOwner,
     AlreadyProjectSubowner,
     AlreadyPendingProjectOwner,
@@ -29,6 +30,7 @@ impl Error {
                 Error::NotAnsweredRegistrationForm
             }
             project::NewProjectErrorKind::SameOwnerSubowner => Error::SameOwnerSubowner,
+            project::NewProjectErrorKind::ArtisticStageProject => Error::ArtisticStageProject,
             project::NewProjectErrorKind::AlreadyProjectOwnerSubowner => Error::AlreadyProjectOwner,
             project::NewProjectErrorKind::AlreadyProjectSubownerSubowner => {
                 Error::AlreadyProjectSubowner

--- a/sos21-use-case/src/create_registration_form.rs
+++ b/sos21-use-case/src/create_registration_form.rs
@@ -119,7 +119,7 @@ mod tests {
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -150,7 +150,7 @@ mod tests {
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -181,7 +181,7 @@ mod tests {
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -195,7 +195,7 @@ mod tests {
                 .map(FormItem::from_entity)
                 .collect(),
             query: ProjectQuery(vec![ProjectQueryConjunction {
-                category: Some(ProjectCategory::General),
+                category: Some(ProjectCategory::GeneralOnline),
                 attributes: vec![],
             }]),
         };

--- a/sos21-use-case/src/distribute_files.rs
+++ b/sos21-use-case/src/distribute_files.rs
@@ -251,7 +251,7 @@ mod tests {
     #[tokio::test]
     async fn test_general() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let (file, object) = test::model::new_file(user.id().clone());
         let scope = file_sharing::FileSharingScope::Project(project.id());
         let sharing = file_sharing::FileSharing::new(file.id, scope);
@@ -283,7 +283,7 @@ mod tests {
     #[tokio::test]
     async fn test_committee() {
         let user = test::model::new_committee_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let (file, object) = test::model::new_file(user.id().clone());
         let scope = file_sharing::FileSharingScope::Project(project.id());
         let sharing = file_sharing::FileSharing::new(file.id, scope);
@@ -318,7 +318,7 @@ mod tests {
         let (file, object) = test::model::new_file(user.id().clone());
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let scope = file_sharing::FileSharingScope::Project(other_project.id());
         let sharing = file_sharing::FileSharing::new(file.id, scope);
@@ -367,7 +367,7 @@ mod tests {
         let (file, object) = test::model::new_file(user.id().clone());
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let scope = file_sharing::FileSharingScope::Project(other_project.id());
         let sharing = file_sharing::FileSharing::new(file.id, scope);
@@ -415,7 +415,7 @@ mod tests {
         let (file, object) = test::model::new_file(user.id().clone());
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let sharing =
             file_sharing::FileSharing::new(file.id, file_sharing::FileSharingScope::Committee);
@@ -454,8 +454,8 @@ mod tests {
 
         let other1 = test::model::new_general_user();
         let other2 = test::model::new_general_user();
-        let other1_project = test::model::new_general_project(other1.id().clone());
-        let other2_project = test::model::new_general_project(other2.id().clone());
+        let other1_project = test::model::new_general_online_project(other1.id().clone());
+        let other2_project = test::model::new_general_online_project(other2.id().clone());
 
         let scope1 = file_sharing::FileSharingScope::Project(other1_project.id());
         let sharing1 = file_sharing::FileSharing::new(file1.id, scope1);
@@ -503,7 +503,7 @@ mod tests {
         let (file, object) = test::model::new_file(user.id().clone());
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])

--- a/sos21-use-case/src/export_form_answers.rs
+++ b/sos21-use-case/src/export_form_answers.rs
@@ -302,8 +302,8 @@ mod tests {
     ) -> (Login<test::context::MockApp>, FormId) {
         let operator = test::model::new_operator_user();
 
-        let project1 = test::model::new_general_project(login_user.id().clone());
-        let project2 = test::model::new_general_project(login_user.id().clone());
+        let project1 = test::model::new_general_online_project(login_user.id().clone());
+        let project2 = test::model::new_general_online_project(login_user.id().clone());
 
         let form1 = test::model::new_form(operator.id().clone());
         let form1_id = FormId::from_entity(form1.id());

--- a/sos21-use-case/src/export_projects.rs
+++ b/sos21-use-case/src/export_projects.rs
@@ -52,10 +52,12 @@ pub struct InputFieldNames {
 
 #[derive(Debug, Clone)]
 pub struct InputCategoryNames {
-    pub general: String,
-    pub stage: String,
-    pub cooking: String,
-    pub food: String,
+    pub general_online: String,
+    pub general_physical: String,
+    pub stage_online: String,
+    pub stage_physical: String,
+    pub cooking_physical: String,
+    pub food_physical: String,
 }
 
 #[tracing::instrument(skip(ctx))]
@@ -318,10 +320,12 @@ where
 
     if category.is_some() {
         let category_name = match data.project.category() {
-            project::ProjectCategory::General => &input.category_names.general,
-            project::ProjectCategory::Stage => &input.category_names.stage,
-            project::ProjectCategory::Cooking => &input.category_names.cooking,
-            project::ProjectCategory::Food => &input.category_names.food,
+            project::ProjectCategory::GeneralOnline => &input.category_names.general_online,
+            project::ProjectCategory::GeneralPhysical => &input.category_names.general_physical,
+            project::ProjectCategory::StageOnline => &input.category_names.stage_online,
+            project::ProjectCategory::StagePhysical => &input.category_names.stage_physical,
+            project::ProjectCategory::CookingPhysical => &input.category_names.cooking_physical,
+            project::ProjectCategory::FoodPhysical => &input.category_names.food_physical,
         };
         writer.write_field(category_name)?;
     }
@@ -490,10 +494,12 @@ mod tests {
             attribute_outdoor: Some("屋外企画".to_string()),
         };
         let category_names = export_projects::InputCategoryNames {
-            general: "一般".to_string(),
-            stage: "ステージ".to_string(),
-            cooking: "調理".to_string(),
-            food: "飲食物取扱".to_string(),
+            general_online: "オンライン一般企画".to_string(),
+            general_physical: "対面一般企画".to_string(),
+            stage_online: "オンラインステージ企画".to_string(),
+            stage_physical: "対面ステージ企画".to_string(),
+            cooking_physical: "調理".to_string(),
+            food_physical: "飲食物取扱".to_string(),
         };
         export_projects::Input {
             field_names,

--- a/sos21-use-case/src/export_projects.rs
+++ b/sos21-use-case/src/export_projects.rs
@@ -450,8 +450,8 @@ mod tests {
 
     async fn prepare_app(login_user: domain::user::User) -> Login<test::context::MockApp> {
         let other = test::model::new_general_user();
-        let project1 = test::model::new_general_project(login_user.id().clone());
-        let project2 = test::model::new_general_project(other.id().clone());
+        let project1 = test::model::new_general_online_project(login_user.id().clone());
+        let project2 = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![login_user.clone(), other.clone()])

--- a/sos21-use-case/src/export_registration_form_answers.rs
+++ b/sos21-use-case/src/export_registration_form_answers.rs
@@ -352,8 +352,9 @@ mod tests {
     ) -> (Login<test::context::MockApp>, RegistrationFormId) {
         let operator = test::model::new_operator_user();
 
-        let project = test::model::new_general_project(login_user.id().clone());
-        let pending_project = test::model::new_general_pending_project(login_user.id().clone());
+        let project = test::model::new_general_online_project(login_user.id().clone());
+        let pending_project =
+            test::model::new_general_online_pending_project(login_user.id().clone());
 
         let registration_form1 = test::model::new_registration_form(operator.id().clone());
         let registration_form1_id = RegistrationFormId::from_entity(registration_form1.id);

--- a/sos21-use-case/src/get_distributed_file.rs
+++ b/sos21-use-case/src/get_distributed_file.rs
@@ -78,10 +78,10 @@ mod tests {
         let (file, object) = test::model::new_file(operator.id().clone());
 
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let scope = file_sharing::FileSharingScope::Project(project.id());
         let sharing = file_sharing::FileSharing::new(file.id, scope);
@@ -119,10 +119,10 @@ mod tests {
         let (file, object) = test::model::new_file(operator.id().clone());
 
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let scope = file_sharing::FileSharingScope::Project(other_project.id());
         let sharing = file_sharing::FileSharing::new(file.id, scope);
@@ -160,7 +160,7 @@ mod tests {
         let (file, object) = test::model::new_file(operator.id().clone());
 
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let scope = file_sharing::FileSharingScope::Project(project.id());
         let sharing = file_sharing::FileSharing::new(file.id, scope);
@@ -198,8 +198,10 @@ mod tests {
 
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
 
         let scope = file_sharing::FileSharingScope::Project(project.id());
         let sharing = file_sharing::FileSharing::new(file.id, scope);

--- a/sos21-use-case/src/get_file_distribution.rs
+++ b/sos21-use-case/src/get_file_distribution.rs
@@ -57,7 +57,7 @@ mod tests {
         let operator = test::model::new_operator_user();
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let (file, object) = test::model::new_file(operator.id().clone());
         let sharing = file_sharing::FileSharing::new(
@@ -95,7 +95,7 @@ mod tests {
         let operator = test::model::new_operator_user();
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let (file, object) = test::model::new_file(operator.id().clone());
         let sharing = file_sharing::FileSharing::new(

--- a/sos21-use-case/src/get_form_answer.rs
+++ b/sos21-use-case/src/get_form_answer.rs
@@ -49,7 +49,7 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let operator = test::model::new_operator_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 
@@ -75,7 +75,7 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let operator = test::model::new_operator_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 
@@ -101,7 +101,7 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let operator = test::model::new_operator_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 

--- a/sos21-use-case/src/get_form_answer_shared_file.rs
+++ b/sos21-use-case/src/get_form_answer_shared_file.rs
@@ -81,7 +81,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
@@ -122,7 +122,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
@@ -164,8 +164,8 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let project = test::model::new_general_project(user.id().clone());
-        let other_project = test::model::new_general_project(other.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
@@ -207,7 +207,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
@@ -251,7 +251,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 

--- a/sos21-use-case/src/get_form_answer_shared_file_object.rs
+++ b/sos21-use-case/src/get_form_answer_shared_file_object.rs
@@ -89,7 +89,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
@@ -130,7 +130,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
@@ -172,8 +172,8 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let project = test::model::new_general_project(user.id().clone());
-        let other_project = test::model::new_general_project(other.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
@@ -215,7 +215,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
@@ -259,7 +259,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 

--- a/sos21-use-case/src/get_pending_project.rs
+++ b/sos21-use-case/src/get_pending_project.rs
@@ -41,7 +41,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_owner() {
         let user = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -62,7 +62,7 @@ mod tests {
     async fn test_get_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(other.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -82,7 +82,7 @@ mod tests {
     #[tokio::test]
     async fn test_not_found() {
         let user = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])

--- a/sos21-use-case/src/get_pending_project_registration_form.rs
+++ b/sos21-use-case/src/get_pending_project_registration_form.rs
@@ -69,7 +69,8 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project_other = test::model::new_general_pending_project(other.id().clone());
+        let pending_project_other =
+            test::model::new_general_online_pending_project(other.id().clone());
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -97,7 +98,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_author() {
         let user = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -127,7 +128,7 @@ mod tests {
         let user = test::model::new_operator_user();
         let pending_project = test::model::new_pending_project_with_attributes(
             user.id().clone(),
-            project::ProjectCategory::General,
+            project::ProjectCategory::GeneralOnline,
             &[
                 project::ProjectAttribute::Academic,
                 project::ProjectAttribute::Artistic,
@@ -172,7 +173,8 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let pending_project_other = test::model::new_general_pending_project(other.id().clone());
+        let pending_project_other =
+            test::model::new_general_online_pending_project(other.id().clone());
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -201,7 +203,8 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let other = test::model::new_general_user();
-        let pending_project_other = test::model::new_general_pending_project(other.id().clone());
+        let pending_project_other =
+            test::model::new_general_online_pending_project(other.id().clone());
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()

--- a/sos21-use-case/src/get_pending_project_registration_form_answer.rs
+++ b/sos21-use-case/src/get_pending_project_registration_form_answer.rs
@@ -85,7 +85,8 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project_other = test::model::new_general_pending_project(other.id().clone());
+        let pending_project_other =
+            test::model::new_general_online_pending_project(other.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
         let answer_other = test::model::new_registration_form_answer_with_pending_project(
             other.id().clone(),
@@ -120,7 +121,8 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let pending_project_other = test::model::new_general_pending_project(other.id().clone());
+        let pending_project_other =
+            test::model::new_general_online_pending_project(other.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
         let answer_other = test::model::new_registration_form_answer_with_pending_project(
             other.id().clone(),
@@ -154,7 +156,8 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let other = test::model::new_general_user();
-        let pending_project_other = test::model::new_general_pending_project(other.id().clone());
+        let pending_project_other =
+            test::model::new_general_online_pending_project(other.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
         let answer_other = test::model::new_registration_form_answer_with_pending_project(
             other.id().clone(),

--- a/sos21-use-case/src/get_project.rs
+++ b/sos21-use-case/src/get_project.rs
@@ -53,7 +53,7 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -72,7 +72,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -94,8 +94,10 @@ mod tests {
     async fn test_general_subowner() {
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
 
         let app = test::build_mock_app()
             .users(vec![owner.clone(), user.clone()])
@@ -117,7 +119,7 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -139,7 +141,7 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -162,7 +164,7 @@ mod tests {
     async fn test_committee_nonexisting_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])

--- a/sos21-use-case/src/get_project_by_code.rs
+++ b/sos21-use-case/src/get_project_by_code.rs
@@ -74,7 +74,7 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -93,7 +93,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -115,8 +115,10 @@ mod tests {
     async fn test_general_subowner() {
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
 
         let app = test::build_mock_app()
             .users(vec![owner.clone(), user.clone()])
@@ -138,7 +140,7 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -160,7 +162,7 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -183,7 +185,7 @@ mod tests {
     async fn test_committee_nonexisting_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -204,7 +206,7 @@ mod tests {
     async fn test_committee_different_kind_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])

--- a/sos21-use-case/src/get_project_form.rs
+++ b/sos21-use-case/src/get_project_form.rs
@@ -61,7 +61,7 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -89,7 +89,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let form = test::model::new_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -113,8 +113,10 @@ mod tests {
     async fn test_general_subowner() {
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
         let form = test::model::new_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -139,7 +141,7 @@ mod tests {
         let user = test::model::new_operator_user();
         let project = test::model::new_project_with_attributes(
             user.id().clone(),
-            project::ProjectCategory::General,
+            project::ProjectCategory::GeneralOnline,
             &[
                 project::ProjectAttribute::Academic,
                 project::ProjectAttribute::Artistic,
@@ -181,7 +183,7 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -205,7 +207,7 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(user.id().clone());
 
         let app = test::build_mock_app()

--- a/sos21-use-case/src/get_project_form_answer.rs
+++ b/sos21-use-case/src/get_project_form_answer.rs
@@ -65,7 +65,7 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         assert!(!project_other.is_visible_to(&user));
         let form = test::model::new_form(other.id().clone());
         let answer_other = test::model::new_form_answer(other.id().clone(), &project_other, &form);
@@ -97,7 +97,7 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(other.id().clone());
         let answer_other = test::model::new_form_answer(other.id().clone(), &project_other, &form);
 
@@ -122,7 +122,7 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let form = test::model::new_form(other.id().clone());
         let answer_other = test::model::new_form_answer(other.id().clone(), &project_other, &form);
 

--- a/sos21-use-case/src/get_project_form_answer_shared_file.rs
+++ b/sos21-use-case/src/get_project_form_answer_shared_file.rs
@@ -111,7 +111,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
         let sharing = file_sharing::FileSharing::new(
@@ -153,7 +153,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 
         let sharing = file_sharing::FileSharing::new(
@@ -196,9 +196,9 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
         let sharing = file_sharing::FileSharing::new(
@@ -242,7 +242,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 
         let mut sharing = file_sharing::FileSharing::new(
@@ -288,7 +288,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 
         let sharing = test::model::new_expired_file_sharing(

--- a/sos21-use-case/src/get_project_form_answer_shared_file_object.rs
+++ b/sos21-use-case/src/get_project_form_answer_shared_file_object.rs
@@ -121,7 +121,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
         let sharing = file_sharing::FileSharing::new(
@@ -163,7 +163,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 
         let sharing = file_sharing::FileSharing::new(
@@ -206,9 +206,9 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let other_answer = test::model::new_form_answer(other.id().clone(), &other_project, &form);
 
         let sharing = file_sharing::FileSharing::new(
@@ -252,7 +252,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 
         let mut sharing = file_sharing::FileSharing::new(
@@ -298,7 +298,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let form = test::model::new_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_form_answer(user.id().clone(), &project, &form);
 
         let sharing = test::model::new_expired_file_sharing(

--- a/sos21-use-case/src/get_project_registration_form.rs
+++ b/sos21-use-case/src/get_project_registration_form.rs
@@ -65,7 +65,7 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -93,7 +93,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -117,8 +117,10 @@ mod tests {
     async fn test_general_subowner() {
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -143,7 +145,7 @@ mod tests {
         let user = test::model::new_operator_user();
         let project = test::model::new_project_with_attributes(
             user.id().clone(),
-            project::ProjectCategory::General,
+            project::ProjectCategory::GeneralOnline,
             &[
                 project::ProjectAttribute::Academic,
                 project::ProjectAttribute::Artistic,
@@ -188,7 +190,7 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()
@@ -212,7 +214,7 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(user.id().clone());
 
         let app = test::build_mock_app()

--- a/sos21-use-case/src/get_project_registration_form_answer.rs
+++ b/sos21-use-case/src/get_project_registration_form_answer.rs
@@ -83,7 +83,7 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
         let answer_other = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
@@ -119,7 +119,7 @@ mod tests {
         let user = test::model::new_general_user();
         let subowner = test::model::new_general_user();
         let operator = test::model::new_operator_user();
-        let project = test::model::new_general_project_with_subowner(
+        let project = test::model::new_general_online_project_with_subowner(
             user.id().clone(),
             subowner.id().clone(),
         );
@@ -157,8 +157,10 @@ mod tests {
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
         let operator = test::model::new_operator_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let answer_other = test::model::new_registration_form_answer_with_project(
             owner.id().clone(),
@@ -192,7 +194,7 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
         let answer_other = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
@@ -226,7 +228,7 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let other = test::model::new_general_user();
-        let project_other = test::model::new_general_project(other.id().clone());
+        let project_other = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(other.id().clone());
         let answer_other = test::model::new_registration_form_answer_with_project(
             other.id().clone(),

--- a/sos21-use-case/src/get_project_registration_form_answer_shared_file.rs
+++ b/sos21-use-case/src/get_project_registration_form_answer_shared_file.rs
@@ -116,7 +116,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
             other_project.id(),
@@ -167,7 +167,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
             project.id(),
@@ -217,8 +217,10 @@ mod tests {
 
         let (owner_file, owner_object) = test::model::new_file(owner.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
         let answer = test::model::new_registration_form_answer_with_project(
             owner.id().clone(),
             project.id(),
@@ -268,13 +270,13 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
             project.id(),
             &registration_form,
         );
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
             other_project.id(),
@@ -327,7 +329,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
             project.id(),
@@ -380,7 +382,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
             project.id(),

--- a/sos21-use-case/src/get_project_registration_form_answer_shared_file_object.rs
+++ b/sos21-use-case/src/get_project_registration_form_answer_shared_file_object.rs
@@ -125,7 +125,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
             other_project.id(),
@@ -176,7 +176,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
             project.id(),
@@ -226,8 +226,10 @@ mod tests {
 
         let (owner_file, owner_object) = test::model::new_file(owner.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
         let answer = test::model::new_registration_form_answer_with_project(
             owner.id().clone(),
             project.id(),
@@ -277,13 +279,13 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
             project.id(),
             &registration_form,
         );
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
             other_project.id(),
@@ -336,7 +338,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
             project.id(),
@@ -389,7 +391,7 @@ mod tests {
 
         let (other_file, other_object) = test::model::new_file(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
             project.id(),

--- a/sos21-use-case/src/get_project_shared_file.rs
+++ b/sos21-use-case/src/get_project_shared_file.rs
@@ -78,7 +78,7 @@ mod tests {
     async fn test_general_others_project() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
         let sharing = file_sharing::FileSharing::new(
@@ -113,7 +113,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner_project() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
@@ -149,8 +149,10 @@ mod tests {
     async fn test_general_subowner_project() {
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
@@ -185,9 +187,9 @@ mod tests {
     #[tokio::test]
     async fn test_general_others_owner() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
         let sharing = file_sharing::FileSharing::new(
@@ -223,7 +225,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner_revoked() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
@@ -261,7 +263,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner_expired() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 

--- a/sos21-use-case/src/get_project_shared_file_object.rs
+++ b/sos21-use-case/src/get_project_shared_file_object.rs
@@ -86,7 +86,7 @@ mod tests {
     async fn test_general_others_project() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
         let sharing = file_sharing::FileSharing::new(
@@ -121,7 +121,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner_project() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
@@ -157,8 +157,10 @@ mod tests {
     async fn test_general_subowner_project() {
         let owner = test::model::new_general_user();
         let user = test::model::new_general_user();
-        let project =
-            test::model::new_general_project_with_subowner(owner.id().clone(), user.id().clone());
+        let project = test::model::new_general_online_project_with_subowner(
+            owner.id().clone(),
+            user.id().clone(),
+        );
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
@@ -193,9 +195,9 @@ mod tests {
     #[tokio::test]
     async fn test_general_others_owner() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
         let sharing = file_sharing::FileSharing::new(
@@ -231,7 +233,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner_revoked() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
@@ -269,7 +271,7 @@ mod tests {
     #[tokio::test]
     async fn test_general_owner_expired() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 

--- a/sos21-use-case/src/get_registration_form_answer.rs
+++ b/sos21-use-case/src/get_registration_form_answer.rs
@@ -55,7 +55,7 @@ mod tests {
     async fn test_general_other() {
         let user = test::model::new_general_user();
         let operator = test::model::new_operator_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let answer = test::model::new_registration_form_answer_with_pending_project(
             user.id().clone(),
@@ -89,7 +89,7 @@ mod tests {
     async fn test_committee_other() {
         let user = test::model::new_committee_user();
         let operator = test::model::new_operator_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let answer = test::model::new_registration_form_answer_with_pending_project(
             user.id().clone(),
@@ -119,7 +119,7 @@ mod tests {
     async fn test_operator_other() {
         let user = test::model::new_operator_user();
         let operator = test::model::new_operator_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let answer = test::model::new_registration_form_answer_with_pending_project(
             user.id().clone(),

--- a/sos21-use-case/src/get_registration_form_answer_shared_file.rs
+++ b/sos21-use-case/src/get_registration_form_answer_shared_file.rs
@@ -90,7 +90,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
@@ -140,7 +140,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
@@ -191,8 +191,8 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let project = test::model::new_general_project(user.id().clone());
-        let other_project = test::model::new_general_project(other.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
@@ -249,7 +249,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
@@ -302,7 +302,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),

--- a/sos21-use-case/src/get_registration_form_answer_shared_file_object.rs
+++ b/sos21-use-case/src/get_registration_form_answer_shared_file_object.rs
@@ -100,7 +100,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
@@ -150,7 +150,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
@@ -201,8 +201,8 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let project = test::model::new_general_project(user.id().clone());
-        let other_project = test::model::new_general_project(other.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let answer = test::model::new_registration_form_answer_with_project(
             user.id().clone(),
@@ -259,7 +259,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),
@@ -312,7 +312,7 @@ mod tests {
         let other = test::model::new_general_user();
         let (other_file, other_object) = test::model::new_file(other.id().clone());
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
         let registration_form = test::model::new_registration_form(operator.id().clone());
         let other_answer = test::model::new_registration_form_answer_with_project(
             other.id().clone(),

--- a/sos21-use-case/src/get_user_pending_project.rs
+++ b/sos21-use-case/src/get_user_pending_project.rs
@@ -43,11 +43,11 @@ mod tests {
     #[tokio::test]
     async fn test_get() {
         let mut user = test::model::new_general_user();
-        let pending_project1 = test::model::new_general_pending_project(user.id().clone());
+        let pending_project1 = test::model::new_general_online_pending_project(user.id().clone());
         user.assign_pending_project_owner(&pending_project1)
             .unwrap();
         let mut other = test::model::new_general_user();
-        let pending_project2 = test::model::new_general_pending_project(other.id().clone());
+        let pending_project2 = test::model::new_general_online_pending_project(other.id().clone());
         other
             .assign_pending_project_owner(&pending_project2)
             .unwrap();
@@ -67,7 +67,7 @@ mod tests {
     async fn test_not_found() {
         let user = test::model::new_general_user();
         let mut other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(other.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(other.id().clone());
         other
             .assign_pending_project_owner(&pending_project)
             .unwrap();

--- a/sos21-use-case/src/get_user_project.rs
+++ b/sos21-use-case/src/get_user_project.rs
@@ -65,9 +65,9 @@ mod tests {
     async fn test_general_owner() {
         let mut user = test::model::new_general_user();
         let mut other = test::model::new_general_user();
-        let project1 = test::model::new_general_project(user.id().clone());
+        let project1 = test::model::new_general_online_project(user.id().clone());
         user.assign_project_owner(&project1).unwrap();
-        let project2 = test::model::new_general_project(other.id().clone());
+        let project2 = test::model::new_general_online_project(other.id().clone());
         other.assign_project_owner(&project2).unwrap();
 
         let app = test::build_mock_app()
@@ -86,10 +86,12 @@ mod tests {
         let mut user = test::model::new_general_user();
         let mut other1 = test::model::new_general_user();
         let mut other2 = test::model::new_general_user();
-        let project1 = test::model::new_general_project(other1.id().clone());
+        let project1 = test::model::new_general_online_project(other1.id().clone());
         other1.assign_project_owner(&project1).unwrap();
-        let project2 =
-            test::model::new_general_project_with_subowner(other2.id().clone(), user.id().clone());
+        let project2 = test::model::new_general_online_project_with_subowner(
+            other2.id().clone(),
+            user.id().clone(),
+        );
         other2.assign_project_owner(&project2).unwrap();
         user.assign_project_subowner(&project2).unwrap();
 
@@ -108,7 +110,7 @@ mod tests {
     async fn test_general_not_found() {
         let user = test::model::new_general_user();
         let mut other = test::model::new_general_user();
-        let project = test::model::new_general_project(other.id().clone());
+        let project = test::model::new_general_online_project(other.id().clone());
         other.assign_project_owner(&project).unwrap();
 
         let app = test::build_mock_app()

--- a/sos21-use-case/src/list_all_file_distributions.rs
+++ b/sos21-use-case/src/list_all_file_distributions.rs
@@ -72,7 +72,7 @@ mod tests {
         let user = test::model::new_operator_user();
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let (file, object) = test::model::new_file(user.id().clone());
         let sharing = file_sharing::FileSharing::new(

--- a/sos21-use-case/src/list_all_projects.rs
+++ b/sos21-use-case/src/list_all_projects.rs
@@ -71,8 +71,8 @@ mod tests {
         login_user: domain::user::User,
     ) -> (Login<test::context::MockApp>, Vec<domain::project::Project>) {
         let other = test::model::new_general_user();
-        let project1 = test::model::new_general_project(login_user.id().clone());
-        let project2 = test::model::new_general_project(other.id().clone());
+        let project1 = test::model::new_general_online_project(login_user.id().clone());
+        let project2 = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![login_user.clone(), other.clone()])

--- a/sos21-use-case/src/list_distributed_files.rs
+++ b/sos21-use-case/src/list_distributed_files.rs
@@ -63,7 +63,7 @@ mod tests {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
 
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone(), other.clone()])
@@ -105,10 +105,10 @@ mod tests {
         use std::collections::HashMap;
 
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let other = test::model::new_general_user();
-        let other_project = test::model::new_general_project(other.id().clone());
+        let other_project = test::model::new_general_online_project(other.id().clone());
 
         let operator = test::model::new_operator_user();
         let (file1, object1, sharing1, distribution1) =

--- a/sos21-use-case/src/list_form_answers.rs
+++ b/sos21-use-case/src/list_form_answers.rs
@@ -58,8 +58,8 @@ mod tests {
     ) -> (Login<test::context::MockApp>, FormId, HashSet<FormAnswerId>) {
         let operator = test::model::new_operator_user();
 
-        let project1 = test::model::new_general_project(login_user.id().clone());
-        let project2 = test::model::new_general_project(login_user.id().clone());
+        let project1 = test::model::new_general_online_project(login_user.id().clone());
+        let project2 = test::model::new_general_online_project(login_user.id().clone());
 
         let form1 = test::model::new_form(operator.id().clone());
         let form1_answer1 =

--- a/sos21-use-case/src/list_pending_project_registration_forms.rs
+++ b/sos21-use-case/src/list_pending_project_registration_forms.rs
@@ -63,7 +63,7 @@ mod tests {
     async fn test_general_any() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let registration_form1 = test::model::new_registration_form(user.id().clone());
         let registration_form2 = test::model::new_registration_form(user.id().clone());
         let registration_form3 = test::model::new_registration_form(other.id().clone());
@@ -102,7 +102,7 @@ mod tests {
         let user = test::model::new_general_user();
         let pending_project = test::model::new_pending_project_with_attributes(
             user.id().clone(),
-            project::ProjectCategory::General,
+            project::ProjectCategory::GeneralOnline,
             &[
                 project::ProjectAttribute::Academic,
                 project::ProjectAttribute::Artistic,

--- a/sos21-use-case/src/list_project_forms.rs
+++ b/sos21-use-case/src/list_project_forms.rs
@@ -58,7 +58,7 @@ mod tests {
     async fn test_general_any() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let form1 = test::model::new_form(user.id().clone());
         let form2 = test::model::new_form(user.id().clone());
         let form3 = test::model::new_form(other.id().clone());
@@ -91,7 +91,7 @@ mod tests {
         let user = test::model::new_general_user();
         let project = test::model::new_project_with_attributes(
             user.id().clone(),
-            project::ProjectCategory::General,
+            project::ProjectCategory::GeneralOnline,
             &[
                 project::ProjectAttribute::Academic,
                 project::ProjectAttribute::Artistic,

--- a/sos21-use-case/src/list_project_registration_forms.rs
+++ b/sos21-use-case/src/list_project_registration_forms.rs
@@ -52,7 +52,7 @@ mod tests {
     async fn test_general_any() {
         let user = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let registration_form1 = test::model::new_registration_form(user.id().clone());
         let registration_form2 = test::model::new_registration_form(user.id().clone());
         let registration_form3 = test::model::new_registration_form(other.id().clone());
@@ -90,7 +90,7 @@ mod tests {
         let user = test::model::new_general_user();
         let project = test::model::new_project_with_attributes(
             user.id().clone(),
-            project::ProjectCategory::General,
+            project::ProjectCategory::GeneralOnline,
             &[
                 project::ProjectAttribute::Academic,
                 project::ProjectAttribute::Artistic,

--- a/sos21-use-case/src/list_registration_form_answers.rs
+++ b/sos21-use-case/src/list_registration_form_answers.rs
@@ -75,8 +75,9 @@ mod tests {
     ) {
         let operator = test::model::new_operator_user();
 
-        let project = test::model::new_general_project(login_user.id().clone());
-        let pending_project = test::model::new_general_pending_project(login_user.id().clone());
+        let project = test::model::new_general_online_project(login_user.id().clone());
+        let pending_project =
+            test::model::new_general_online_pending_project(login_user.id().clone());
 
         let registration_form1 = test::model::new_registration_form(operator.id().clone());
         let registration_form1_answer1 = test::model::new_registration_form_answer_with_project(

--- a/sos21-use-case/src/model/project.rs
+++ b/sos21-use-case/src/model/project.rs
@@ -19,28 +19,34 @@ impl ProjectId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ProjectCategory {
-    General,
-    Stage,
-    Cooking,
-    Food,
+    GeneralOnline,
+    GeneralPhysical,
+    StageOnline,
+    StagePhysical,
+    CookingPhysical,
+    FoodPhysical,
 }
 
 impl ProjectCategory {
     pub fn from_entity(category: entity::ProjectCategory) -> ProjectCategory {
         match category {
-            entity::ProjectCategory::General => ProjectCategory::General,
-            entity::ProjectCategory::Stage => ProjectCategory::Stage,
-            entity::ProjectCategory::Cooking => ProjectCategory::Cooking,
-            entity::ProjectCategory::Food => ProjectCategory::Food,
+            entity::ProjectCategory::GeneralOnline => ProjectCategory::GeneralOnline,
+            entity::ProjectCategory::GeneralPhysical => ProjectCategory::GeneralPhysical,
+            entity::ProjectCategory::StageOnline => ProjectCategory::StageOnline,
+            entity::ProjectCategory::StagePhysical => ProjectCategory::StagePhysical,
+            entity::ProjectCategory::CookingPhysical => ProjectCategory::CookingPhysical,
+            entity::ProjectCategory::FoodPhysical => ProjectCategory::FoodPhysical,
         }
     }
 
     pub fn into_entity(self) -> entity::ProjectCategory {
         match self {
-            ProjectCategory::General => entity::ProjectCategory::General,
-            ProjectCategory::Stage => entity::ProjectCategory::Stage,
-            ProjectCategory::Cooking => entity::ProjectCategory::Cooking,
-            ProjectCategory::Food => entity::ProjectCategory::Food,
+            ProjectCategory::GeneralOnline => entity::ProjectCategory::GeneralOnline,
+            ProjectCategory::GeneralPhysical => entity::ProjectCategory::GeneralPhysical,
+            ProjectCategory::StageOnline => entity::ProjectCategory::StageOnline,
+            ProjectCategory::StagePhysical => entity::ProjectCategory::StagePhysical,
+            ProjectCategory::CookingPhysical => entity::ProjectCategory::CookingPhysical,
+            ProjectCategory::FoodPhysical => entity::ProjectCategory::FoodPhysical,
         }
     }
 }

--- a/sos21-use-case/src/prepare_project.rs
+++ b/sos21-use-case/src/prepare_project.rs
@@ -29,6 +29,7 @@ pub enum Error {
     AlreadyProjectSubowner,
     AlreadyPendingProjectOwner,
     OutOfCreationPeriod,
+    ArtisticStageProject,
 }
 
 impl Error {
@@ -69,6 +70,9 @@ impl Error {
             }
             pending_project::NewPendingProjectErrorKind::OutOfCreationPeriod => {
                 Error::OutOfCreationPeriod
+            }
+            pending_project::NewPendingProjectErrorKind::ArtisticStageProject => {
+                Error::ArtisticStageProject
             }
         }
     }

--- a/sos21-use-case/src/prepare_project.rs
+++ b/sos21-use-case/src/prepare_project.rs
@@ -142,7 +142,7 @@ mod tests {
             group_name: test::model::mock_project_group_name().into_string(),
             kana_group_name: test::model::mock_project_kana_group_name().into_string(),
             description: test::model::mock_project_description().into_string(),
-            category: ProjectCategory::General,
+            category: ProjectCategory::GeneralOnline,
             attributes: Vec::new(),
         };
         (name, input)
@@ -175,7 +175,7 @@ mod tests {
         let period = test::model::new_project_creation_period_from_now();
         let app = test::build_mock_app()
             .users(vec![user.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -198,7 +198,7 @@ mod tests {
         let period = test::model::new_project_creation_period_with_hours_from_now(1);
         let app = test::build_mock_app()
             .users(vec![user.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -218,7 +218,7 @@ mod tests {
         let period = test::model::new_project_creation_period_to_now();
         let app = test::build_mock_app()
             .users(vec![user.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user.clone())
             .await;
@@ -235,7 +235,7 @@ mod tests {
     #[tokio::test]
     async fn test_already_project_owner() {
         let mut user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         user.assign_project_owner(&project).unwrap();
 
         let app = test::build_mock_app()

--- a/sos21-use-case/src/update_any_pending_project.rs
+++ b/sos21-use-case/src/update_any_pending_project.rs
@@ -159,7 +159,7 @@ mod tests {
     #[tokio::test]
     async fn test_general() {
         let user = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -190,7 +190,7 @@ mod tests {
     #[tokio::test]
     async fn test_committee() {
         let user = test::model::new_committee_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -221,7 +221,7 @@ mod tests {
     #[tokio::test]
     async fn test_operator() {
         let user = test::model::new_operator_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -252,7 +252,7 @@ mod tests {
     #[tokio::test]
     async fn test_admin() {
         let user = test::model::new_admin_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])

--- a/sos21-use-case/src/update_any_project.rs
+++ b/sos21-use-case/src/update_any_project.rs
@@ -178,7 +178,7 @@ mod tests {
     #[tokio::test]
     async fn test_general() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -209,7 +209,7 @@ mod tests {
     #[tokio::test]
     async fn test_committee() {
         let user = test::model::new_committee_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -240,7 +240,7 @@ mod tests {
     #[tokio::test]
     async fn test_operator() {
         let user = test::model::new_operator_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
@@ -271,7 +271,7 @@ mod tests {
     #[tokio::test]
     async fn test_admin() {
         let user = test::model::new_admin_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])

--- a/sos21-use-case/src/update_pending_project.rs
+++ b/sos21-use-case/src/update_pending_project.rs
@@ -170,13 +170,13 @@ mod tests {
     #[tokio::test]
     async fn test_general_out_of_period() {
         let user = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let period = test::model::new_project_creation_period_to_now();
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
             .pending_projects(vec![pending_project.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user)
             .await;
@@ -194,13 +194,13 @@ mod tests {
     #[tokio::test]
     async fn test_general_in_period() {
         let user = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(user.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(user.id().clone());
         let period = test::model::new_project_creation_period_from_now();
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
             .pending_projects(vec![pending_project.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user)
             .await;

--- a/sos21-use-case/src/update_pending_project_registration_form_answer.rs
+++ b/sos21-use-case/src/update_pending_project_registration_form_answer.rs
@@ -185,7 +185,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_in_period_general_owner() {
         let owner = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(owner.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (item_id, items, answer_items) = prepare_items();
@@ -237,7 +237,7 @@ mod tests {
     async fn test_answer_in_period_general_other() {
         let owner = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(owner.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (item_id, items, answer_items) = prepare_items();
@@ -283,7 +283,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_after_period_owner() {
         let owner = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(owner.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (_, items, answer_items) = prepare_items();
@@ -326,7 +326,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_in_period_invalid() {
         let owner = test::model::new_general_user();
-        let pending_project = test::model::new_general_pending_project(owner.id().clone());
+        let pending_project = test::model::new_general_online_pending_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (_, items, answer_items) = prepare_items();

--- a/sos21-use-case/src/update_project.rs
+++ b/sos21-use-case/src/update_project.rs
@@ -183,13 +183,13 @@ mod tests {
     #[tokio::test]
     async fn test_general_out_of_period() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let period = test::model::new_project_creation_period_to_now();
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
             .projects(vec![project.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user)
             .await;
@@ -207,13 +207,13 @@ mod tests {
     #[tokio::test]
     async fn test_general_in_period() {
         let user = test::model::new_general_user();
-        let project = test::model::new_general_project(user.id().clone());
+        let project = test::model::new_general_online_project(user.id().clone());
         let period = test::model::new_project_creation_period_from_now();
 
         let app = test::build_mock_app()
             .users(vec![user.clone()])
             .projects(vec![project.clone()])
-            .project_creation_period_for(project::ProjectCategory::General, period)
+            .project_creation_period_for(project::ProjectCategory::GeneralOnline, period)
             .build()
             .login_as(user)
             .await;

--- a/sos21-use-case/src/update_project_form_answer.rs
+++ b/sos21-use-case/src/update_project_form_answer.rs
@@ -160,7 +160,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_in_period_general_owner() {
         let owner = test::model::new_general_user();
-        let project = test::model::new_general_project(owner.id().clone());
+        let project = test::model::new_general_online_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (item_id, items, answer_items) = prepare_items();
@@ -207,7 +207,7 @@ mod tests {
     async fn test_answer_in_period_general_subowner() {
         let owner = test::model::new_general_user();
         let subowner = test::model::new_general_user();
-        let project = test::model::new_general_project_with_subowner(
+        let project = test::model::new_general_online_project_with_subowner(
             owner.id().clone(),
             subowner.id().clone(),
         );
@@ -257,7 +257,7 @@ mod tests {
     async fn test_answer_in_period_general_other() {
         let owner = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project = test::model::new_general_project(owner.id().clone());
+        let project = test::model::new_general_online_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (item_id, items, answer_items) = prepare_items();
@@ -302,7 +302,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_after_period_owner() {
         let owner = test::model::new_general_user();
-        let project = test::model::new_general_project(owner.id().clone());
+        let project = test::model::new_general_online_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let period = test::model::new_form_period_to_now();
@@ -334,7 +334,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_in_period_invalid() {
         let owner = test::model::new_general_user();
-        let project = test::model::new_general_project(owner.id().clone());
+        let project = test::model::new_general_online_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let form = test::model::new_form(operator.id().clone());

--- a/sos21-use-case/src/update_project_registration_form_answer.rs
+++ b/sos21-use-case/src/update_project_registration_form_answer.rs
@@ -176,7 +176,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_in_period_general_owner() {
         let owner = test::model::new_general_user();
-        let project = test::model::new_general_project(owner.id().clone());
+        let project = test::model::new_general_online_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (item_id, items, answer_items) = prepare_items();
@@ -226,7 +226,7 @@ mod tests {
     async fn test_answer_in_period_general_subowner() {
         let owner = test::model::new_general_user();
         let subowner = test::model::new_general_user();
-        let project = test::model::new_general_project_with_subowner(
+        let project = test::model::new_general_online_project_with_subowner(
             owner.id().clone(),
             subowner.id().clone(),
         );
@@ -279,7 +279,7 @@ mod tests {
     async fn test_answer_in_period_general_other() {
         let owner = test::model::new_general_user();
         let other = test::model::new_general_user();
-        let project = test::model::new_general_project(owner.id().clone());
+        let project = test::model::new_general_online_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (item_id, items, answer_items) = prepare_items();
@@ -325,7 +325,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_after_period_owner() {
         let owner = test::model::new_general_user();
-        let project = test::model::new_general_project(owner.id().clone());
+        let project = test::model::new_general_online_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (_, items, answer_items) = prepare_items();
@@ -366,7 +366,7 @@ mod tests {
     #[tokio::test]
     async fn test_answer_in_period_invalid() {
         let owner = test::model::new_general_user();
-        let project = test::model::new_general_project(owner.id().clone());
+        let project = test::model::new_general_online_project(owner.id().clone());
         let operator = test::model::new_operator_user();
 
         let (_, items, answer_items) = prepare_items();


### PR DESCRIPTION
#### Excuse: Why add suffixes instead of creating a new field like `isOnline`
I suppose this pull request does not solve the issue in a evil dirty way, but I submit this because of the following reasons:

- Online/Offline flag and project category is completely different information and should be the independent field for each.
- However, since there are categories that don't allow online, splitting them is kinda complicated (Of course making a new field is the ideal and better way though)
- Furthermore, it's an urgent update.