### PR TITLE
Change Project Code format to `([PO][GS]|[CF])[0-9]{3}`

### DIFF
--- a/sos21-domain/src/model/project.rs
+++ b/sos21-domain/src/model/project.rs
@@ -319,14 +319,9 @@ impl Project {
     pub fn is_member(&self, user: &User) -> bool {
         &self.owner_id == user.id() || &self.subowner_id == user.id()
     }
-
     pub fn kind(&self) -> ProjectKind {
-        ProjectKind {
-            is_cooking: self.content.category == ProjectCategory::CookingPhysical,
-            is_outdoor: self.content.attributes.contains(ProjectAttribute::Outdoor),
-        }
+        self.category().into()
     }
-
     pub fn code(&self) -> ProjectCode {
         ProjectCode {
             kind: self.kind(),

--- a/sos21-domain/src/model/project/code.rs
+++ b/sos21-domain/src/model/project/code.rs
@@ -126,10 +126,10 @@ impl ProjectCode {
             }
         };
 
-        let index_slice = match s.len(){
+        let index_slice = match s.len() {
             4 => &s[1..4],
-            5=> &s[2..5],
-            _=> unreachable!()
+            5 => &s[2..5],
+            _ => unreachable!(),
         };
 
         let index = str::from_utf8(index_slice).map_err(ParseCodeError::from_index_utf8_error)?;

--- a/sos21-use-case/src/get_project_by_code.rs
+++ b/sos21-use-case/src/get_project_by_code.rs
@@ -68,6 +68,7 @@ mod tests {
     use crate::model::project::ProjectId;
     use crate::{get_project_by_code, UseCaseError};
     use sos21_domain::test;
+    use sos21_domain::model::project::ProjectKind;
 
     // Checks that the normal user cannot read the others' project.
     #[tokio::test]
@@ -216,7 +217,7 @@ mod tests {
             .await;
 
         let mut code = project_other.code();
-        code.kind.is_cooking = !code.kind.is_cooking;
+        code.kind = ProjectKind::General { is_online: false };
         assert!(matches!(
             get_project_by_code::run(&app, code.to_string()).await,
             Err(UseCaseError::UseCase(get_project_by_code::Error::NotFound))

--- a/sos21-use-case/src/get_project_by_code.rs
+++ b/sos21-use-case/src/get_project_by_code.rs
@@ -67,8 +67,8 @@ where
 mod tests {
     use crate::model::project::ProjectId;
     use crate::{get_project_by_code, UseCaseError};
-    use sos21_domain::test;
     use sos21_domain::model::project::ProjectKind;
+    use sos21_domain::test;
 
     // Checks that the normal user cannot read the others' project.
     #[tokio::test]


### PR DESCRIPTION
Change project code format.

- `P` reperesents *physical* (on-site) , and `O` means `online`
- `G` stands for  *general* (一般企画)
- `S` :  *stage*
- `C`: *Cooking* (Onsite-only)
- `F`: *Food* (Onsite-only)