### PR TITLE
Enable manual dispatch event for workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -2,7 +2,9 @@ on:
   push:
     branches:
       - 'release/*'
-
+  workflow_dispatch:
+    branches:
+      - 'release/*'
 name: Beta
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ on:
   push:
     branches:
       - 'main'
-
+  workflow_dispatch:
+    branches:
+      - 'main'
 name: Main
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Send Slack notification when a new form answer is submitted
+- Enable `workflow_dispatch` event on Beta/Main Workflows
 
 ### Changed
 ### Deprecated


### PR DESCRIPTION
Manual re-running of workflows is necessary to apply new configurations that are updated on GitHub secrets.