### PR TITLE
Endpoint to check if project creation is available now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Send Slack notification when a new form answer is submitted
 - Enable `workflow_dispatch` event on Beta/Main Workflows
+- `/get-project-creation-availability` endpoint to check if it's in a project creation period ([#157](https://github.com/sohosai/sos21-backend/pull/157))
+
 
 ### Changed
 ### Deprecated

--- a/sos21-api-server/schema/api.yml
+++ b/sos21-api-server/schema/api.yml
@@ -6122,6 +6122,32 @@ paths:
       operationId: meta/get-build-info
       description: ビルド時の情報を取得します。
       security: []
+  /get-project-creation-availability:
+    get:
+      description: '各企画区分について、企画登録期間かどうかを調べます。'
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  timestamp:
+                    type: number
+                  general_online:
+                    type: boolean
+                  general_physical:
+                    type: boolean
+                  stage_online:
+                    type: boolean
+                  stage_physical:
+                    type: boolean
+                  cooking_physical:
+                    type: boolean
+                  food_physical:
+                    type: boolean
 components:
   securitySchemes:
     token:

--- a/sos21-api-server/schema/api.yml
+++ b/sos21-api-server/schema/api.yml
@@ -6124,7 +6124,10 @@ paths:
       security: []
   /get-project-creation-availability:
     get:
-      description: "各企画区分について、企画登録期間かどうかを調べます。"
+      summary: /get-project-creation-availability
+      tags:
+        - project
+        - pending_project
       parameters: []
       responses:
         "200":
@@ -6148,6 +6151,9 @@ paths:
                     type: boolean
                   food_physical:
                     type: boolean
+      operationId: get-project-creation-availability
+      description: "各企画区分について、企画登録期間かどうかを調べます。"
+      security: []
 components:
   securitySchemes:
     token:

--- a/sos21-api-server/schema/api.yml
+++ b/sos21-api-server/schema/api.yml
@@ -6124,10 +6124,10 @@ paths:
       security: []
   /get-project-creation-availability:
     get:
-      description: '各企画区分について、企画登録期間かどうかを調べます。'
+      description: "各企画区分について、企画登録期間かどうかを調べます。"
       parameters: []
       responses:
-        '200':
+        "200":
           description: OK
           content:
             application/json:

--- a/sos21-api-server/src/filter.rs
+++ b/sos21-api-server/src/filter.rs
@@ -94,6 +94,7 @@ pub fn endpoints(
             },
             / "file-sharing" / "list" => GET (handler::me::file_sharing::list),
         },
+        / "get-project-creation-availability" =>{noauth}  GET(handler::project_creation_availability::get),
         / "project" {
             / "prepare" => POST (handler::project::prepare),
             / "create" => POST (handler::project::create),

--- a/sos21-api-server/src/handler.rs
+++ b/sos21-api-server/src/handler.rs
@@ -260,6 +260,8 @@ pub use invite_user::handler as invite_user;
 pub mod assign_user_role_to_email;
 pub use assign_user_role_to_email::handler as assign_user_role_to_email;
 
+pub mod project_creation_availability;
+
 pub trait HandlerResponse: Serialize {
     /// Server errors are returned as `anyhow::Error`, not as `HandlerResponse`.
     /// Thus, it always stands that `!x.status_code().is_server_error()`.

--- a/sos21-api-server/src/handler/project_creation_availability.rs
+++ b/sos21-api-server/src/handler/project_creation_availability.rs
@@ -1,0 +1,2 @@
+pub mod get;
+pub use get::handler as get;

--- a/sos21-api-server/src/handler/project_creation_availability/get.rs
+++ b/sos21-api-server/src/handler/project_creation_availability/get.rs
@@ -1,0 +1,62 @@
+use crate::app::Context;
+use crate::handler::model::date_time::DateTime;
+use crate::handler::{HandlerResponse, HandlerResult};
+
+use serde::{Deserialize, Serialize};
+use sos21_use_case::get_project_creation_availability;
+use sos21_use_case::model::project_creation_availability::ProjectCreationAvailability;
+use warp::http::StatusCode;
+
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Response {
+    pub timestamp: DateTime,
+    pub general_online: bool,
+    pub general_physical: bool,
+    pub stage_online: bool,
+    pub stage_physical: bool,
+    pub cooking_physical: bool,
+    pub food_physical: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE", tag = "type")]
+pub enum Error {}
+
+impl HandlerResponse for Error {
+    fn status_code(&self) -> StatusCode {
+        match *self {}
+    }
+}
+
+impl HandlerResponse for Response {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::OK
+    }
+}
+
+#[macro_rules_attribute::macro_rules_attribute(handler!)]
+pub async fn handler(ctx: Context,_request: Request) -> HandlerResult<Response,Error> {
+    let ProjectCreationAvailability {
+        timestamp,
+        general_online,
+        general_physical,
+        stage_online,
+        stage_physical,
+        cooking_physical,
+        food_physical,
+    } = get_project_creation_availability::run(&ctx);
+
+    Ok(Response {
+        timestamp:DateTime::from_use_case(timestamp),
+        general_online,
+        general_physical,
+        stage_online,
+        stage_physical,
+        cooking_physical,
+        food_physical,
+    })
+}

--- a/sos21-api-server/src/handler/project_creation_availability/get.rs
+++ b/sos21-api-server/src/handler/project_creation_availability/get.rs
@@ -7,7 +7,6 @@ use sos21_use_case::get_project_creation_availability;
 use sos21_use_case::model::project_creation_availability::ProjectCreationAvailability;
 use warp::http::StatusCode;
 
-
 #[derive(Debug, Clone, Deserialize)]
 pub struct Request {}
 
@@ -39,7 +38,7 @@ impl HandlerResponse for Response {
 }
 
 #[macro_rules_attribute::macro_rules_attribute(handler!)]
-pub async fn handler(ctx: Context,_request: Request) -> HandlerResult<Response,Error> {
+pub async fn handler(ctx: Context, _request: Request) -> HandlerResult<Response, Error> {
     let ProjectCreationAvailability {
         timestamp,
         general_online,
@@ -51,7 +50,7 @@ pub async fn handler(ctx: Context,_request: Request) -> HandlerResult<Response,E
     } = get_project_creation_availability::run(&ctx);
 
     Ok(Response {
-        timestamp:DateTime::from_use_case(timestamp),
+        timestamp: DateTime::from_use_case(timestamp),
         general_online,
         general_physical,
         stage_online,

--- a/sos21-use-case/src/get_project_creation_availability.rs
+++ b/sos21-use-case/src/get_project_creation_availability.rs
@@ -1,0 +1,100 @@
+use crate::model::project_creation_availability::ProjectCreationAvailability;
+
+use chrono::Utc;
+use sos21_domain::context::ConfigContext;
+use sos21_domain::model::date_time::DateTime;
+use sos21_domain::model::project::ProjectCategory;
+
+#[tracing::instrument(skip(ctx))]
+pub fn run<C>(ctx: C) -> ProjectCreationAvailability
+where
+    C: ConfigContext + Send + Sync,
+{
+    let now = Utc::now();
+    let now_entity = DateTime::from_utc(now);
+
+    ProjectCreationAvailability {
+        timestamp: now,
+        general_physical: ctx
+            .project_creation_period_for(ProjectCategory::GeneralPhysical)
+            .contains(now_entity),
+        general_online: ctx
+            .project_creation_period_for(ProjectCategory::GeneralOnline)
+            .contains(now_entity),
+        stage_physical: ctx
+            .project_creation_period_for(ProjectCategory::StagePhysical)
+            .contains(now_entity),
+        stage_online: ctx
+            .project_creation_period_for(ProjectCategory::StageOnline)
+            .contains(now_entity),
+        cooking_physical: ctx
+            .project_creation_period_for(ProjectCategory::CookingPhysical)
+            .contains(now_entity),
+        food_physical: ctx
+            .project_creation_period_for(ProjectCategory::FoodPhysical)
+            .contains(now_entity),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration;
+    use sos21_domain::model::project::ProjectCategory;
+    use sos21_domain::model::project_creation_period::{self, ProjectCreationPeriod};
+    use sos21_domain::test;
+
+    use crate::model::project_creation_availability::ProjectCreationAvailability;
+
+    // Checks that it returns correct project creation availability at runtime
+    #[tokio::test]
+    async fn test_availability() {
+        let user = test::model::new_general_user();
+        let other = test::model::new_general_user();
+        let operator = test::model::new_operator_user();
+
+        let now = Utc::now();
+        let past_period = ProjectCreationPeriod::from_datetime(
+            now - Duration::minutes(10),
+            now - Duration::minutes(5),
+        );
+        let ongoing_period = ProjectCreationPeriod::from_datetime(
+            now - Duration::minutes(5),
+            now + Duration::minutes(5),
+        );
+        let future_period = ProjectCreationPeriod::from_datetime(
+            now + Duration::minutes(5),
+            now + Duration::minutes(10),
+        );
+
+        let app = test::build_mock_app()
+            .users(vec![user.clone(), other.clone(), operator.clone()])
+            .project_creation_period_for(
+                ProjectCategory::GeneralOnline,
+                ProjectCreationPeriod::never(),
+            )
+            .project_creation_period_for(
+                ProjectCategory::GeneralPhysical,
+                ProjectCreationPeriod::always(),
+            )
+            .project_creation_period_for(ProjectCategory::StageOnline, past_period)
+            .project_creation_period_for(ProjectCategory::StagePhysical, ongoing_period)
+            .project_creation_period_for(ProjectCategory::CookingPhysical, future_period)
+            .project_creation_period_for(ProjectCategory::FoodPhysical, ongoing_period)
+            .build()
+            .login_as(user.clone())
+            .await;
+
+        assert!(matches!(
+            get_project_creation_availability::run(&app, input).await,
+            ProjectCreationAvailability{
+                timestamp: _,
+                general_online: false, // never
+                general_physical: true, // always
+                stage_online: false// past
+                stage_physical: true // ongoing
+                cooking_physical: false // future
+                food_physical: true // ongoing
+            }
+        ));
+    }
+}

--- a/sos21-use-case/src/lib.rs
+++ b/sos21-use-case/src/lib.rs
@@ -50,6 +50,7 @@ pub mod get_pending_project_registration_form;
 pub mod get_pending_project_registration_form_answer;
 pub mod get_project;
 pub mod get_project_by_code;
+pub mod get_project_creation_availability;
 pub mod get_project_form;
 pub mod get_project_form_answer;
 pub mod get_project_form_answer_shared_file;

--- a/sos21-use-case/src/model.rs
+++ b/sos21-use-case/src/model.rs
@@ -7,6 +7,7 @@ pub mod form;
 pub mod form_answer;
 pub mod pending_project;
 pub mod project;
+pub mod project_creation_availability;
 pub mod project_query;
 pub mod registration_form;
 pub mod registration_form_answer;

--- a/sos21-use-case/src/model/project_creation_availability.rs
+++ b/sos21-use-case/src/model/project_creation_availability.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime,Utc};
+use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ProjectCreationAvailability {

--- a/sos21-use-case/src/model/project_creation_availability.rs
+++ b/sos21-use-case/src/model/project_creation_availability.rs
@@ -1,0 +1,12 @@
+use chrono::{DateTime,Utc};
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProjectCreationAvailability {
+    pub timestamp: DateTime<Utc>,
+    pub general_online: bool,
+    pub general_physical: bool,
+    pub stage_online: bool,
+    pub stage_physical: bool,
+    pub cooking_physical: bool,
+    pub food_physical: bool,
+}


### PR DESCRIPTION
- Implemented an endpoint to check if project creation is available now

- GET `/get-project-creation-availability` should result something like this:

```json
{
 "timestamp":1655834858836,
 "general_online":true,
 "general_physical":true,
 "stage_online":false,
 "stage_physical":false,
 "cooking_physical":false,
 "food_physical":false
}
```

- This is intended to remove the  constants  in regard to the project creation period at sos21-frontend